### PR TITLE
Create gemspec for initial version

### DIFF
--- a/lib/rubocop-performance.rb
+++ b/lib/rubocop-performance.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require_relative 'rubocop_performance/version'

--- a/lib/rubocop_performance/version.rb
+++ b/lib/rubocop_performance/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RuboCopPerformance
+  module Version
+    STRING = '0.1.0'
+  end
+end

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'rubocop-performance/version'
+
+Gem::Specification.new do |s|
+  s.name = 'rubocop-performance'
+  s.version = RuboCopPerformance::Version::STRING
+  s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 2.3.0'
+  s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
+  s.description = <<-DESCRIPTION
+    A collection of RuboCop cops to check for performance optimizations
+    in Ruby code.
+  DESCRIPTION
+
+  s.email = 'rubocop@googlegroups.com'
+  s.files = `git ls-files config lib LICENSE.txt README.md`.split($RS)
+  s.extra_rdoc_files = ['LICENSE.txt', 'README.md']
+  s.homepage = 'https://github.com/rubocop-hq/rubocop-performance'
+  s.licenses = ['MIT']
+  s.summary = 'Automatic performance checking tool for Ruby code.'
+
+  s.metadata = {
+    'homepage_uri' => 'https://rubocop-performance.readthedocs.io/',
+    'changelog_uri' => 'https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md',
+    'source_code_uri' => 'https://github.com/rubocop-hq/rubocop-performance/',
+    'documentation_uri' => 'https://rubocop-performance.readthedocs.io/',
+    'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-performance/issues'
+  }
+
+  s.add_runtime_dependency('rubocop', '~> 0.57')
+end


### PR DESCRIPTION
I broke this off from #1

I took as much as I could from
https://github.com/rubocop-hq/rubocop/blob/master/rubocop.gemspec
then changed the names and descriptions for rubocop-performance.

The gemspec expects LICENSE.txt to exist, so #2 should go in
first.