### PR TITLE
Fix directory file name

### DIFF
--- a/lib/rubocop-performance.rb
+++ b/lib/rubocop-performance.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 require 'rubocop'
-require_relative 'rubocop_performance/version'
+require_relative 'rubocop/performance/version'

--- a/lib/rubocop/performance/version.rb
+++ b/lib/rubocop/performance/version.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Performance
+    module Version
+      STRING = '0.1.0'
+    end
+  end
+end

--- a/lib/rubocop_performance/version.rb
+++ b/lib/rubocop_performance/version.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module RuboCopPerformance
-  module Version
-    STRING = '0.1.0'
-  end
-end

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'rubocop-performance/version'
+require 'rubocop/performance/version'
 
 Gem::Specification.new do |s|
   s.name = 'rubocop-performance'
-  s.version = RuboCopPerformance::Version::STRING
+  s.version = RuboCop::Performance::Version::STRING
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 2.3.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']


### PR DESCRIPTION
I seem to be confused about rspec-performance vs. rspec_performance.
Right now we have a mismatch between the require in the gemspec and the
version file, so the gem will not build. For now I'm going with the
dash, since it matches the name of the gem, but I'm not entirely
confident that is correct.

https://github.com/rubocop-hq/rubocop-performance/blob/c551accab8ce0710c6248163d7aeccb1819751ba/rubocop-performance.gemspec#L4