### PR TITLE
Create a default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,3 +15,7 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
+
+task default: %i[
+  spec
+]


### PR DESCRIPTION
I was going to include RuboCop linting in this task, but RuboCop doesn't appear to be in a good state yet.