### PR TITLE
Set up circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,73 @@
+version: 2
+
+rspec: &rspec
+  steps:
+    - checkout
+    - run: bundle install
+    - run: rake spec
+
+jobs:
+  # Ruby 2.3
+  ruby-2.3-rspec:
+    docker:
+      - image: circleci/ruby:2.3
+    <<: *rspec
+
+  # Ruby 2.4
+  ruby-2.4-rspec:
+    docker:
+      - image: circleci/ruby:2.4
+    <<: *rspec
+
+  # Ruby 2.5
+  ruby-2.5-rspec:
+    docker:
+      - image: circleci/ruby:2.5
+    <<: *rspec
+
+  # JRuby
+  jruby:
+    docker:
+      - image: circleci/jruby:9
+    steps:
+      - checkout
+      - run: sudo apt-get install -y make
+      - run: bundle lock
+      - restore_cache:
+          keys:
+            - bundle-v2-{{ checksum "Gemfile.lock" }}
+            - bundle-v2-
+      - run: bundle install --path vendor/bundle
+      - save_cache:
+          key: bundle-v2-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - run: rake spec
+
+  code-climate:
+    docker:
+      - image: circleci/ruby:2.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+      - run:
+          name: Run specs
+          command: |
+            ./cc-test-reporter before-build
+            rake coverage
+            ./cc-test-reporter after-build --exit-code $?
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - ruby-2.3-rspec
+      - ruby-2.4-rspec
+      - ruby-2.5-rspec
+      - jruby
+      - code-climate

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp
+coverage

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,12 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
 
+desc 'Run RSpec with code coverage'
+task :coverage do
+  ENV['COVERAGE'] = 'true'
+  Rake::Task['spec'].execute
+end
+
 task default: %i[
   spec
 ]

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency('rubocop', '~> 0.57')
+  s.add_development_dependency('simplecov')
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,11 @@
 require 'rubocop-performance'
 require 'rubocop/rspec/support'
 
+if ENV['COVERAGE'] == 'true'
+  require 'simplecov'
+  SimpleCov.start
+end
+
 RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense
 


### PR DESCRIPTION
I based the circle config largely on the one from rubocop-rspec.
I removed the rubocop and documentation builds, since I haven't added
those rake tasks yet (I am working on documentation, and see #11 for
rubocop.) I also removed the Ruby 2.1 and 2.2 builds, since those
versions are no longer supported.

I went ahead and added the coverage rake task as well.

closes #10

NOTE: The tests will all fail until we get #13 in. It probably makes sense to merge that first, then rebase this and watch them pass. @bbatsov would it be possible to add this repo to circle when you have a chance?