### PR TITLE
Preparing for 0.0.0 release

### DIFF
--- a/lib/rubocop/performance/version.rb
+++ b/lib/rubocop/performance/version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Performance
     module Version
-      STRING = '0.1.0'
+      STRING = '0.0.0'
     end
   end
 end


### PR DESCRIPTION
This release aims to reserve a gem name called rubocop-performance.