### PR TITLE
Import Performance cop configs from RuboCop Core

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,10 @@
+# This is the default configuration file.
+
+Performance/DoubleStartEndWith:
+  # Used to check for `starts_with?` and `ends_with?`.
+  # These methods are defined by `ActiveSupport`.
+  IncludeActiveSupportAliases: false
+
+Performance/RedundantMerge:
+  # Max number of key-value pairs to consider an offense
+  MaxKeyValuePairs: 2


### PR DESCRIPTION
This PR imports settings of default.yml related to Performance department from RuboCop Core.

Because all Performance cops are enabled, enabled.yml and disabled.yml are not imported.