### PR TITLE
Change offense message for `Performance/Casecmp`

### DIFF
--- a/spec/rubocop/cop/performance/casecmp_spec.rb
+++ b/spec/rubocop/cop/performance/casecmp_spec.rb
@@ -82,21 +82,36 @@ RSpec.describe RuboCop::Cop::Performance::Casecmp do
 
     it "formats the error message correctly for str.#{selector} ==" do
       inspect_source("str.#{selector} == 'string'")
-      expect(cop.highlights).to eq(["#{selector} =="])
-      expect(cop.messages).to eq(["Use `casecmp` instead of `#{selector} ==`."])
+      expect(cop.highlights).to eq(["str.#{selector} == 'string'"])
+      expect(cop.messages).to eq(
+        [
+          "Use `str.casecmp('string').zero?` instead of " \
+          "`str.#{selector} == 'string'`."
+        ]
+      )
     end
 
     it "formats the error message correctly for == str.#{selector}" do
       inspect_source("'string' == str.#{selector}")
-      expect(cop.highlights).to eq(["== str.#{selector}"])
-      expect(cop.messages).to eq(["Use `casecmp` instead of `== #{selector}`."])
+      expect(cop.highlights).to eq(["'string' == str.#{selector}"])
+      expect(cop.messages).to eq(
+        [
+          "Use `str.casecmp('string').zero?` instead of " \
+          "`'string' == str.#{selector}`."
+        ]
+      )
     end
 
     it 'formats the error message correctly for ' \
        "obj.#{selector} == str.#{selector}" do
       inspect_source("obj.#{selector} == str.#{selector}")
       expect(cop.highlights).to eq(["obj.#{selector} == str.#{selector}"])
-      expect(cop.messages).to eq(["Use `casecmp` instead of `#{selector} ==`."])
+      expect(cop.messages).to eq(
+        [
+          'Use `obj.casecmp(str).zero?` instead of ' \
+          "`obj.#{selector} == str.#{selector}`."
+        ]
+      )
     end
 
     it "doesn't report an offense for variable == str.#{selector}" do


### PR DESCRIPTION
This PR imports rubocop-hq/rubocop#6156.

This PR changes offense message for `Performance/Casecmp` cop.
An example of an offense message change for the following code.

```console
% cat casecmp.rb
str.downcase == 'abc'
```

## Before

```console
% rubocop casecmp.rb --only Performance/Casecmp
Inspecting 1 file
C

Offenses:

casecmp.rb:1:5: C: Performance/Casecmp: Use casecmp instead of downcase
==.
str.downcase == 'abc'
    ^^^^^^^^^^^

1 file inspected, 1 offense detected
```

## After

```console
% rubocop casecmp.rb --only Performance/Casecmp
Inspecting 1 file
C

Offenses:

casecmp.rb:1:1: C: Performance/Casecmp: Use str.casecmp('abc').zero?
instead of str.downcase == 'abc'.
str.downcase == 'abc'
^^^^^^^^^^^^^^^^^^^^^
```

This change makes it clear that users need to replace on the whole
including `zero?` method when replacing with `casecmp` method.