### PR TITLE
[Fix #22] Change runtime dependency RuboCop to 0.58.0 or higher

### DIFF
--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-performance/issues'
   }
 
-  s.add_runtime_dependency('rubocop', '~> 0.58')
+  s.add_runtime_dependency('rubocop', '>= 0.58.0')
   s.add_development_dependency('simplecov')
 end


### PR DESCRIPTION
Fixes #22.

This PR specifies the same dependency version as rubocop-hq/rubocop-rspec#664.