### PR TITLE
Add `rake new_cop` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,3 +36,27 @@ task default: %i[
   generate_cops_documentation
   spec
 ]
+
+desc 'Generate a new cop template'
+task :new_cop, [:cop] do |_task, args|
+  require 'rubocop'
+
+  cop_name = args.fetch(:cop) do
+    warn 'usage: bundle exec rake new_cop[Department/Name]'
+    exit!
+  end
+
+  github_user = `git config github.user`.chop
+  github_user = 'your_id' if github_user.empty?
+
+  generator = RuboCop::Cop::Generator.new(cop_name, github_user)
+
+  generator.write_source
+  generator.write_spec
+  generator.inject_require(
+    root_file_path: 'lib/rubocop/cop/performance_cops.rb'
+  )
+  generator.inject_config(config_file_path: 'config/default.yml')
+
+  puts generator.todo
+end


### PR DESCRIPTION
The `rake new_cop` task was copied based on the following commit in the ruboscop-rspec.
https://github.com/rubocop-hq/rubocop-rspec/blob/v1.32.0/Rakefile#L65-L85