### PR TITLE
Add .github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug Report
+about: Report an issue with RuboCop Performance you've discovered.
+---
+
+*Be clear, concise and precise in your description of the problem.
+Open an issue with a descriptive title and a summary in grammatically correct,
+complete sentences.*
+
+*Use the template below when reporting bugs. Please, make sure that
+you're running the latest stable RuboCop and that the problem you're reporting
+hasn't been reported (and potentially fixed) already.*
+
+*Before filing the ticket you should replace all text above the horizontal
+rule with your own words.*
+
+--------
+
+## Expected behavior
+
+Describe here how you expected RuboCop Performance to behave in this particular situation.
+
+## Actual behavior
+
+Describe here what actually happened.
+
+## Steps to reproduce the problem
+
+This is extremely important! Providing us with a reliable way to reproduce
+a problem will expedite its solution.
+
+## RuboCop version
+
+Include the output of `rubocop -V` or `bundle exec rubocop -V` if using Bundler. Here's an example:
+
+```
+$ [bundle exec] rubocop -V
+0.65.0 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-linux)
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest new RuboCop Performance features or improvements to existing features.
+---
+
+## Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+**Replace this text with a summary of the changes in your PR.
+The more detailed you are, the better.**
+
+-----------------
+
+Before submitting the PR make sure the following are checked:
+
+* [ ] Wrote [good commit messages][1].
+* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
+* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
+* [ ] Squashed related commits together.
+* [ ] Added tests.
+* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
+* [ ] The PR relates to *only* one subject with a clear title
+  and description in grammatically correct, complete sentences.
+* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
+
+[1]: https://chris.beams.io/posts/git-commit/


### PR DESCRIPTION
This PR adds .github template based on the ruboscop-hq/rubocop repository.
https://github.com/rubocop-hq/rubocop/tree/v0.65.0/.github