### PR TITLE
Add readthedocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: "Performance optimization analysis for your projects, as an extension to RuboCop."
+repo_url: https://github.com/rubocop-hq/rubocop-performance
+edit_uri: edit/master/manual/
+copyright: "Copyright &copy; 2012-2019 Bozhidar Batsov and RuboCop contributors"
+docs_dir: manual
+pages:
+- Home: index.md
+- Installation: installation.md
+- Usage: usage.md
+- Cops: cops.md
+- Cops Documentation:
+    - Performance Cops: cops_performance.md
+theme: readthedocs

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+    image: stable
+
+formats:
+    - htmlzip


### PR DESCRIPTION
This PR adds readthedocs.yml.

It is expected that the following homepage will be pushlished by this setting.

https://rubocop-performance.readthedocs.io/

Refer https://github.com/rubocop-hq/rubocop-performance/blob/v1.0.0/rubocop-performance.gemspec#L25.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
