### PR TITLE
Add project spec

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+RSpec.describe 'RuboCop Performance Project', type: :feature do
+  describe 'changelog' do
+    subject(:changelog) do
+      path = File.join(File.dirname(__FILE__), '..', 'CHANGELOG.md')
+      File.read(path)
+    end
+
+    let(:lines) { changelog.each_line }
+
+    let(:non_reference_lines) do
+      lines.take_while { |line| !line.start_with?('[@') }
+    end
+
+    it 'has newline at end of file' do
+      expect(changelog.end_with?("\n")).to be true
+    end
+
+    it 'has either entries, headers, or empty lines' do
+      expect(non_reference_lines).to all(match(/^(\*|#|$)/))
+    end
+
+    it 'has link definitions for all implicit links' do
+      implicit_link_names = changelog.scan(/\[([^\]]+)\]\[\]/).flatten.uniq
+      implicit_link_names.each do |name|
+        expect(changelog.include?("[#{name}]: http"))
+          .to be(true), "CHANGELOG.md is missing a link for #{name}. " \
+                        'Please add this link to the bottom of the file.'
+      end
+    end
+
+    describe 'entry' do
+      subject(:entries) { lines.grep(/^\*/).map(&:chomp) }
+
+      it 'has a whitespace between the * and the body' do
+        expect(entries).to all(match(/^\* \S/))
+      end
+
+      context 'after version 0.14.0' do
+        let(:lines) do
+          changelog.each_line.take_while do |line|
+            !line.start_with?('## 0.14.0')
+          end
+        end
+
+        it 'has a link to the contributors at the end' do
+          expect(entries).to all(match(/\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/))
+        end
+      end
+
+      describe 'link to related issue' do
+        let(:issues) do
+          entries.map do |entry|
+            entry.match(/\[(?<number>[#\d]+)\]\((?<url>[^\)]+)\)/)
+          end.compact
+        end
+
+        it 'has an issue number prefixed with #' do
+          issues.each do |issue|
+            expect(issue[:number]).to match(/^#\d+$/)
+          end
+        end
+
+        it 'has a valid URL' do
+          issues.each do |issue|
+            number = issue[:number].gsub(/\D/, '')
+            pattern = %r{^https://github\.com/rubocop-hq/rubocop-performance/(?:issues|pull)/#{number}$} # rubocop:disable Metrics/LineLength
+            expect(issue[:url]).to match(pattern)
+          end
+        end
+
+        it 'has a colon and a whitespace at the end' do
+          entries_including_issue_link = entries.select do |entry|
+            entry.match(/^\*\s*\[/)
+          end
+
+          expect(entries_including_issue_link).to all(include('): '))
+        end
+      end
+
+      describe 'contributor name' do
+        subject(:contributor_names) { lines.grep(/\A\[@/).map(&:chomp) }
+
+        it 'has a unique contributor name' do
+          expect(contributor_names.uniq.size).to eq contributor_names.size
+        end
+      end
+
+      describe 'body' do
+        let(:bodies) do
+          entries.map do |entry|
+            entry
+              .gsub(/`[^`]+`/, '``')
+              .sub(/^\*\s*(?:\[.+?\):\s*)?/, '')
+              .sub(/\s*\([^\)]+\)$/, '')
+          end
+        end
+
+        it 'does not start with a lower case' do
+          bodies.each do |body|
+            expect(body).not_to match(/^[a-z]/)
+          end
+        end
+
+        it 'ends with a punctuation' do
+          expect(bodies).to all(match(/[\.\!]$/))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on the following project spec added to RuboCop Rails.
https://github.com/rubocop-hq/rubocop-rails/commit/8641ef97c1387b03ecb300dfef38aab123c77067

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
