### PR TITLE
Update `require` statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ ways to do this:
 Put this into your `.rubocop.yml`.
 
 ```yaml
-require: rubocop-performance
+AllCops:
+  Require: rubocop-performance
 ```
 
 Now you can run `rubocop` and it will automatically load the RuboCop Performance


### PR DESCRIPTION
Adding `require: rubocop-performance` on top of your rubocop yml will throw an exception:
```
Error running RuboCop Error: cannot load such file -- rubocop-performance ../2.5.0/rubygems/core_ext/kernel_require.rb:54:in require
```
The solution is to nest it under `AllCops`, the [docs](https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#includingexcluding-files) actually suggest that. Keys like `Include`/`Exclude` are all capitalized, so why not capitalize `require` as well?

I guess, there is no need to bump the version for this? (-:

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/

--------------

from the CI:
```
#!/bin/bash -eo pipefail
bundle exec rake
bundle exec rubocop
Inspecting 69 files
.....................................................................

69 files inspected, no offenses detected
Files:          30
Modules:         3 (    2 undocumented)
Classes:        30 (    0 undocumented)
Constants:      54 (   49 undocumented)
Attributes:      0 (    0 undocumented)
Methods:        61 (   55 undocumented)
 28.38% documented
rake aborted!
RuboCop::ValidationError: The `Performance/LstripRstrip` cop has been moved to `Style/Strip`
(obsolete configuration found in config/default.yml, please update it)
/usr/local/bundle/gems/rubocop-0.67.2/lib/rubocop/config.rb:560:in `reject_obsolete_cops_and_parameters'
/usr/local/bundle/gems/rubocop-0.67.2/lib/rubocop/config.rb:363:in `validate'
/usr/local/bundle/gems/rubocop-0.67.2/lib/rubocop/config.rb:249:in `check'
/usr/local/bundle/gems/rubocop-0.67.2/lib/rubocop/config.rb:242:in `create'
/usr/local/bundle/gems/rubocop-0.67.2/lib/rubocop/config_loader.rb:53:in `load_file'
tasks/cops_documentation.rake:248:in `main'
tasks/cops_documentation.rake:260:in `block in <top (required)>'
/usr/local/bundle/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => default => generate_cops_documentation
(See full trace by running task with --trace)
Exited with code 1
```