### PR TITLE
Preparing for 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 1.1.0 (2019-04-08)
+
 ### Changes
 
 * [#39](https://github.com/rubocop-hq/rubocop-performance/pull/39): Remove `Performance/LstripRstrip` cop. ([@koic][])

--- a/lib/rubocop/performance/version.rb
+++ b/lib/rubocop/performance/version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Performance
     module Version
-      STRING = '1.0.0'.freeze
+      STRING = '1.1.0'.freeze
     end
   end
 end

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop-performance'
   s.version = RuboCop::Performance::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.2.2'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<-DESCRIPTION
     A collection of RuboCop cops to check for performance optimizations
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-performance/issues'
   }
 
-  s.add_runtime_dependency('rubocop', '>= 0.58.0')
+  s.add_runtime_dependency('rubocop', '>= 0.67.0')
   s.add_development_dependency('simplecov')
 end


### PR DESCRIPTION
Several performance cops were moved to the style department in the RuboCop 0.67.
https://github.com/rubocop-hq/rubocop/releases/tag/v0.67.0

According to that, the next RuboCop Performance release requires RuboCop 0.67 or higher.

The next RuboCop Perfomance release removes some perfomance cops and bumps the dependent RuboCop version. So this PR makes the next release version to 1.1.0 instead of 1.0.1.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
