### PR TITLE
Remove unused message format for `Performance/OpenStruct`

### DIFF
--- a/lib/rubocop/cop/performance/open_struct.rb
+++ b/lib/rubocop/cop/performance/open_struct.rb
@@ -36,8 +36,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          open_struct(node) do |method|
-            add_offense(node, location: :selector, message: format(MSG, method))
+          open_struct(node) do
+            add_offense(node, location: :selector)
           end
         end
       end


### PR DESCRIPTION
This PR suppresses the following warning.

```console
% path/to/rubocop-performance
% bundle exec rake

(snip)

/Users/koic/src/github.com/rubocop-hq/rubocop-performance/lib/rubocop/cop/performance/open_struct.rb:40:
warning: too many arguments for format string
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
