### PR TITLE
Suppress `Object#=~` deprecation warning

### DIFF
--- a/lib/rubocop/cop/performance/string_replacement.rb
+++ b/lib/rubocop/cop/performance/string_replacement.rb
@@ -86,7 +86,8 @@ module RuboCop
 
           unless first_param.str_type?
             return true if options
-            return true unless first_source =~ DETERMINISTIC_REGEX
+            return true unless first_source.is_a?(String) &&
+                               first_source =~ DETERMINISTIC_REGEX
 
             # This must be done after checking DETERMINISTIC_REGEX
             # Otherwise things like \s will trip us up


### PR DESCRIPTION
This PR suppresses the following warning.

```console
/Users/koic/src/github.com/rubocop-hq/rubocop-performance/lib/rubocop/cop/performance/string_replacement.rb:89:
warning: deprecated Object#=~ is called on RuboCop::AST::Node; it always
returns nil
```

`Object#=~` has been deprecated from Ruby 2.6.
https://github.com/ruby/ruby/commit/ebff9dc10e6e72239c23e50acc7d3cbfdc659e7a

Related commit: https://github.com/ruby/ruby/commit/f7e94df0d66aff47745d189ab5a7858a92233d57

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
