### PR TITLE
Use edge RuboCop for development

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@
 inherit_from: .rubocop_todo.yml
 require:
   - rubocop/cop/internal_affairs
+  - rubocop-performance
   - rubocop-rspec
 
 AllCops:

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,12 @@
 
 source 'https://rubygems.org'
 
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
 gemspec
 
 gem 'rake'
 gem 'rspec'
+gem 'rubocop', github: 'rubocop-hq/rubocop'
 gem 'rubocop-rspec', '~> 1.29.0'
 gem 'yard', '~> 0.9'


### PR DESCRIPTION
Use edge RuboCop core for development

This PR uses edge RuboCop core for development. It is for RuboCop Performance to early catch change of RuboCop Core which is the runtime dependency gem.

And this PR suppresses the following warning by specifying rubocop-performance in .rubocop.yml

```console
% cd path/to/rubocop-performance
% bundle exec rake
bundle exec rubocop
Warning: unrecognized cop Performance/Caller found in .rubocop.yml
Inspecting 61 files
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
