### PR TITLE
Fix a false negartive for `Performance/RegexpMatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#47](https://github.com/rubocop-hq/rubocop-performance/pull/47): Fix a false negartive for `Performance/RegexpMatch` when using RuboCop 0.68 or higher. ([@koic][])
+
 ## 1.1.0 (2019-04-08)
 
 ### Changes

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -86,8 +86,8 @@ module RuboCop
 
         def_node_matcher :match_method?, <<-PATTERN
           {
+            (send _recv :match _ <int ...>)
             (send _recv :match _)
-            (send _recv :match _ (int ...))
           }
         PATTERN
 

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-performance/issues'
   }
 
-  s.add_runtime_dependency('rubocop', '>= 0.67.0')
+  s.add_runtime_dependency('rubocop', '>= 0.68.0')
   s.add_development_dependency('simplecov')
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/pull/6965.

This PR fixes a false negartive for `Performance/RegexpMatch` when using RuboCop 0.68 or higher.

```ruby
# example.rb
def foo
  if /re/.match(foo, 1)
    do_something
  end
end
```

## RuboCop 0.67

RuboCop 0.67 warns.

```console
% rubocop _0.67.2_ --only Performance/RegexpMatch
Inspecting 1 file
C

Offenses:

example.rb:2:6: C: Performance/RegexpMatch: Use match? instead of match
when MatchData is not used.
  if /re/.match(foo, 1)
       ^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

## RuboCop 0.68 (Before)

RuboCop 0.68 does not warn. This is a false negative.

```console
% rubocop _0.68.1_ --only Performance/RegexpMatch --require
rubocop-performance
Inspecting 1 file
.

1 file inspected, no offenses detected
```

## RuboCop 0.68 (After)

This PR fixes a false negative.

```console
% rubocop --only Performance/RegexpMatch --require rubocop-performance
Inspecting 1 file
C

Offenses:

example.rb:2:6: C: Performance/RegexpMatch: Use match? instead of match
when MatchData is not used.
  if /re/.match(foo, 1)
       ^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

This fix uses the following `<>` node pattern notation introduced in RuboCop 0.68, so it supports Ruby version 0.68 or higher.
https://github.com/rubocop-hq/rubocop/pull/6965

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
