### PR TITLE
[Fix #48] Fix RegexpMatch false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#48](https://github.com/rubocop-hq/rubocop-performance/issues/48): Reduce `Performance/RegexpMatch` false positive by only flagging `match` used with Regexp/String/Symbol literals. ([@dduugg][])
+
 ### Changes
 
 * [#52](https://github.com/rubocop-hq/rubocop-performance/issues/52): Drop support for Ruby 2.2. ([@bquorning][])
@@ -10,7 +14,7 @@
 
 ### Bug fixes
 
-* [#47](https://github.com/rubocop-hq/rubocop-performance/pull/47): Fix a false negartive for `Performance/RegexpMatch` when using RuboCop 0.68 or higher. ([@koic][])
+* [#47](https://github.com/rubocop-hq/rubocop-performance/pull/47): Fix a false negative for `Performance/RegexpMatch` when using RuboCop 0.68 or higher. ([@koic][])
 
 ## 1.1.0 (2019-04-08)
 
@@ -28,3 +32,4 @@
 [@composerinteralia]: https://github.com/composerinteralia
 [@koic]: https://github.com/koic
 [@bquorning]: https://github.com/bquorning
+[@dduugg]: https://github.com/dduugg

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -80,14 +80,14 @@ module RuboCop
         # Constants are included in this list because it is unlikely that
         # someone will store `nil` as a constant and then use it for comparison
         TYPES_IMPLEMENTING_MATCH = %i[const regexp str sym].freeze
-        MSG =
-          'Use `match?` instead of `%<current>s` when `MatchData` ' \
+        MSG = 'Use `match?` instead of `%<current>s` when `MatchData` ' \
           'is not used.'
 
         def_node_matcher :match_method?, <<-PATTERN
           {
             (send _recv :match _ <int ...>)
-            (send _recv :match _)
+            (send _recv :match {regexp str sym})
+            (send {regexp str sym} :match _)
           }
         PATTERN
 

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -381,5 +381,13 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
         end
       RUBY
     end
+
+    it 'accepts match without explicit regexp/str/sym use' do
+      expect_no_offenses(<<-RUBY)
+        if CONST.match(var)
+          do_something
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
This fixes false positives in `Performance/RegexpMatch` by only flagging single-argument `match` methods where either the receiver or the argument is a literal of type `Regexp`, `String`, `Symbol`.

Resolves https://github.com/rubocop-hq/rubocop-performance/issues/48

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
