### PR TITLE
[Fix #50] Make EndWith/StartWith autocorrects nil-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
 ### Bug fixes
 
 * [#54](https://github.com/rubocop-hq/rubocop-performance/issues/54): Fix `Performance/FixedSize` to accept const assign with some operation. ([@tejasbubane][])
+* [#50](https://github.com/rubocop-hq/rubocop-performance/issues/50): Make `Performance/EndWith` and `Performance/StartWith` autocorrects nil-safe. ([@dduugg][])
 
 ## 1.3.0 (2019-05-13)
 
 ### Bug fixes
 
-* [#48](https://github.com/rubocop-hq/rubocop-performance/issues/48): Reduce `Performance/RegexpMatch` false positive by only flagging `match` used with Regexp/String/Symbol literals. ([@dduugg][])
+* [#48](https://github.com/rubocop-hq/rubocop-performance/issues/48): Reduce `Performance/RegexpMatch` false positives by only flagging `match` used with Regexp/String/Symbol literals. ([@dduugg][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -82,7 +82,6 @@ Performance/EndWith:
   # object. Switching these methods has to be done with knowledge of the types
   # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
-  AutoCorrect: false
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.44'
@@ -176,7 +175,6 @@ Performance/StartWith:
   # object. Switching these methods has to be done with knowledge of the types
   # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
-  AutoCorrect: false
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.44'

--- a/lib/rubocop/cop/performance/end_with.rb
+++ b/lib/rubocop/cop/performance/end_with.rb
@@ -44,7 +44,7 @@ module RuboCop
             regex_str = interpret_string_escapes(regex_str)
 
             lambda do |corrector|
-              new_source = receiver.source + '.end_with?(' +
+              new_source = receiver.source + '&.end_with?(' +
                            to_string_literal(regex_str) + ')'
               corrector.replace(node.source_range, new_source)
             end

--- a/lib/rubocop/cop/performance/start_with.rb
+++ b/lib/rubocop/cop/performance/start_with.rb
@@ -47,7 +47,7 @@ module RuboCop
             regex_str = interpret_string_escapes(regex_str)
 
             lambda do |corrector|
-              new_source = receiver.source + '.start_with?(' +
+              new_source = receiver.source + '&.start_with?(' +
                            to_string_literal(regex_str) + ')'
               corrector.replace(node.source_range, new_source)
             end

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -324,7 +324,7 @@ would suffice.
 
 Name | Default value | Configurable values
 --- | --- | ---
-AutoCorrect | `false` | Boolean
+AutoCorrect | `true` | Boolean
 
 ### References
 
@@ -775,7 +775,7 @@ This cop identifies unnecessary use of a regex where
 
 Name | Default value | Configurable values
 --- | --- | ---
-AutoCorrect | `false` | Boolean
+AutoCorrect | `true` | Boolean
 
 ### References
 

--- a/spec/rubocop/cop/performance/end_with_spec.rb
+++ b/spec/rubocop/cop/performance/end_with_spec.rb
@@ -6,23 +6,23 @@ RSpec.describe RuboCop::Cop::Performance::EndWith do
   shared_examples 'different match methods' do |method|
     it "autocorrects #{method} /abc\\z/" do
       new_source = autocorrect_source("str#{method} /abc\\z/")
-      expect(new_source).to eq "str.end_with?('abc')"
+      expect(new_source).to eq "str&.end_with?('abc')"
     end
 
     it "autocorrects #{method} /\\n\\z/" do
       new_source = autocorrect_source("str#{method} /\\n\\z/")
-      expect(new_source).to eq 'str.end_with?("\n")'
+      expect(new_source).to eq 'str&.end_with?("\n")'
     end
 
     it "autocorrects #{method} /\\t\\z/" do
       new_source = autocorrect_source("str#{method} /\\t\\z/")
-      expect(new_source).to eq 'str.end_with?("\t")'
+      expect(new_source).to eq 'str&.end_with?("\t")'
     end
 
     %w[. $ ^ |].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
         new_source = autocorrect_source("str#{method} /\\#{str}\\z/")
-        expect(new_source).to eq "str.end_with?('#{str}')"
+        expect(new_source).to eq "str&.end_with?('#{str}')"
       end
 
       it "doesn't register an error for #{method} /#{str}\\z/" do
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Performance::EndWith do
     %w[a e f r t v].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
         new_source = autocorrect_source("str#{method} /\\#{str}\\z/")
-        expect(new_source).to eq %{str.end_with?("\\#{str}")}
+        expect(new_source).to eq %{str&.end_with?("\\#{str}")}
       end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::Performance::EndWith do
     %w[i j l m o q y].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
         new_source = autocorrect_source("str#{method} /\\#{str}\\z/")
-        expect(new_source).to eq "str.end_with?('#{str}')"
+        expect(new_source).to eq "str&.end_with?('#{str}')"
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::Performance::EndWith do
 
     it "autocorrects #{method} /\\\\\\z/" do
       new_source = autocorrect_source("str#{method} /\\\\\\z/")
-      expect(new_source).to eq("str.end_with?('\\\\')")
+      expect(new_source).to eq("str&.end_with?('\\\\')")
     end
   end
 

--- a/spec/rubocop/cop/performance/start_with_spec.rb
+++ b/spec/rubocop/cop/performance/start_with_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Performance::StartWith do
   shared_examples 'different match methods' do |method|
     it "autocorrects #{method} /\\Aabc/" do
       new_source = autocorrect_source("str#{method} /\\Aabc/")
-      expect(new_source).to eq "str.start_with?('abc')"
+      expect(new_source).to eq "str&.start_with?('abc')"
     end
 
     # escapes like "\n"
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Performance::StartWith do
     %w[a e f r t v].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
         new_source = autocorrect_source("str#{method} /\\A\\#{str}/")
-        expect(new_source).to eq %{str.start_with?("\\#{str}")}
+        expect(new_source).to eq %{str&.start_with?("\\#{str}")}
       end
     end
 
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Performance::StartWith do
     %w[. * ? $ ^ |].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
         new_source = autocorrect_source("str#{method} /\\A\\#{str}/")
-        expect(new_source).to eq "str.start_with?('#{str}')"
+        expect(new_source).to eq "str&.start_with?('#{str}')"
       end
 
       it "doesn't register an error for #{method} /\\A#{str}/" do
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::Performance::StartWith do
     %w[i j l m o q y].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
         new_source = autocorrect_source("str#{method} /\\A\\#{str}/")
-        expect(new_source).to eq "str.start_with?('#{str}')"
+        expect(new_source).to eq "str&.start_with?('#{str}')"
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::Performance::StartWith do
 
     it "autocorrects #{method} /\\A\\\\/" do
       new_source = autocorrect_source("str#{method} /\\A\\\\/")
-      expect(new_source).to eq("str.start_with?('\\\\')")
+      expect(new_source).to eq("str&.start_with?('\\\\')")
     end
   end
 


### PR DESCRIPTION
Makes the autocorrects for `Performance/EndWith` and `Performance/StartWith` safe to use with `nil` receivers, by invoking the autocorrected methods (`end_with?` and `start_with?`) with safe navigation where supported (ruby versions >= 2.3).

I've also enabled autocorrect for these cops in the default config. The autocorrect remains unsafe (particularly when correcting `Symbol` receivers, which do not support `end_with?` and `start_with?`, but this is captured by the `SafeAutoCorrect` setting. I'm happy to revert if the reviewer disagrees.

Ruby versions < 2.3 are not addressed, for reasons described in the linked ticket (impending end of support for the releases in rubocop core).

I've split the tests by ruby version where it mattered. This triggered the `RSpec/RepeatedExample` cop, which i evaded by some slight tweaks to the receiver name in the examples (`s`, `str`, `string`). Again, happy to take a different approach if the reviewer would like.

Fixes https://github.com/rubocop-hq/rubocop-performance/issues/50

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
