### PR TITLE
Drop support for Ruby 2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ workflows:
   build:
     jobs:
       - rake_default:
-          name: Ruby 2.2
-          image: circleci/ruby:2.2
-      - rake_default:
           name: Ruby 2.3
           image: circleci/ruby:2.3
       - rake_default:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Naming/PredicateName:
   # Method define macros for dynamically generated method.
@@ -20,9 +20,6 @@ Naming/PredicateName:
     - define_singleton_method
     - def_node_matcher
     - def_node_search
-
-Style/FrozenStringLiteralComment:
-  EnforcedStyle: always
 
 Style/FormatStringToken:
   # Because we parse a lot of source codes from strings. Percent arrays
@@ -53,9 +50,6 @@ Layout/ClassStructure:
       - instance_methods
       - protected_methods
       - private_methods
-
-Layout/IndentHeredoc:
-  EnforcedStyle: powerpack
 
 # Trailing white space is meaningful in code examples
 Layout/TrailingWhitespace:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#52](https://github.com/rubocop-hq/rubocop-performance/issues/52): Drop support for Ruby 2.2. ([@bquorning][])
+
 ## 1.2.0 (2019-05-04)
 
 ### Bug fixes
@@ -23,3 +27,4 @@
 
 [@composerinteralia]: https://github.com/composerinteralia
 [@koic]: https://github.com/koic
+[@bquorning]: https://github.com/bquorning

--- a/lib/rubocop/cop/performance/caller.rb
+++ b/lib/rubocop/cop/performance/caller.rb
@@ -20,9 +20,9 @@ module RuboCop
       #   caller_locations(1..1).first
       class Caller < Cop
         MSG_BRACE = 'Use `%<method>s(%<n>d..%<n>d).first`' \
-                    ' instead of `%<method>s[%<m>d]`.'.freeze
+                    ' instead of `%<method>s[%<m>d]`.'
         MSG_FIRST = 'Use `%<method>s(%<n>d..%<n>d).first`' \
-                    ' instead of `%<method>s.first`.'.freeze
+                    ' instead of `%<method>s.first`.'
 
         def_node_matcher :slow_caller?, <<-PATTERN
           {

--- a/lib/rubocop/cop/performance/case_when_splat.rb
+++ b/lib/rubocop/cop/performance/case_when_splat.rb
@@ -58,9 +58,9 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Reordering `when` conditions with a splat to the end ' \
-          'of the `when` branches can improve performance.'.freeze
+          'of the `when` branches can improve performance.'
         ARRAY_MSG = 'Pass the contents of array literals ' \
-          'directly to `when` conditions.'.freeze
+          'directly to `when` conditions.'
 
         def on_case(case_node)
           when_conditions = case_node.when_branches.flat_map(&:conditions)

--- a/lib/rubocop/cop/performance/casecmp.rb
+++ b/lib/rubocop/cop/performance/casecmp.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   str.casecmp('ABC').zero?
       #   'abc'.casecmp(str).zero?
       class Casecmp < Cop
-        MSG = 'Use `%<good>s` instead of `%<bad>s`.'.freeze
+        MSG = 'Use `%<good>s` instead of `%<bad>s`.'
         CASE_METHODS = %i[downcase upcase].freeze
 
         def_node_matcher :downcase_eq, <<-PATTERN

--- a/lib/rubocop/cop/performance/chain_array_allocation.rb
+++ b/lib/rubocop/cop/performance/chain_array_allocation.rb
@@ -29,10 +29,10 @@ module RuboCop
         #   [1,2].first    # => 1
         #   [1,2].first(1) # => [1]
         #
-        RETURN_NEW_ARRAY_WHEN_ARGS = ':first :last :pop :sample :shift '.freeze
+        RETURN_NEW_ARRAY_WHEN_ARGS = ':first :last :pop :sample :shift '
 
         # These methods return a new array only when called without a block.
-        RETURNS_NEW_ARRAY_WHEN_NO_BLOCK = ':zip :product '.freeze
+        RETURNS_NEW_ARRAY_WHEN_NO_BLOCK = ':zip :product '
 
         # These methods ALWAYS return a new array
         # after they're called it's safe to mutate the the resulting array
@@ -40,16 +40,16 @@ module RuboCop
                                    ':drop_while :flatten :map :reject ' \
                                    ':reverse :rotate :select :shuffle :sort ' \
                                    ':take :take_while :transpose :uniq ' \
-                                   ':values_at :| '.freeze
+                                   ':values_at :| '
 
         # These methods have a mutation alternative. For example :collect
         # can be called as :collect!
         HAS_MUTATION_ALTERNATIVE = ':collect :compact :flatten :map :reject '\
                                    ':reverse :rotate :select :shuffle :sort '\
-                                   ':uniq '.freeze
+                                   ':uniq '
         MSG = 'Use unchained `%<method>s!` and `%<second_method>s!` '\
               '(followed by `return array` if required) instead of chaining '\
-              '`%<method>s...%<second_method>s`.'.freeze
+              '`%<method>s...%<second_method>s`.'
 
         def_node_matcher :flat_map_candidate?, <<-PATTERN
           {

--- a/lib/rubocop/cop/performance/compare_with_block.rb
+++ b/lib/rubocop/cop/performance/compare_with_block.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         MSG = 'Use `%<compare_method>s_by%<instead>s` instead of ' \
               '`%<compare_method>s { |%<var_a>s, %<var_b>s| %<str_a>s ' \
-              '<=> %<str_b>s }`.'.freeze
+              '<=> %<str_b>s }`.'
 
         def_node_matcher :compare?, <<-PATTERN
           (block

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -41,7 +41,7 @@ module RuboCop
         include SafeMode
         include RangeHelp
 
-        MSG = 'Use `count` instead of `%<selector>s...%<counter>s`.'.freeze
+        MSG = 'Use `count` instead of `%<selector>s...%<counter>s`.'
 
         def_node_matcher :count_candidate?, <<-PATTERN
           {

--- a/lib/rubocop/cop/performance/detect.rb
+++ b/lib/rubocop/cop/performance/detect.rb
@@ -26,9 +26,9 @@ module RuboCop
         include SafeMode
 
         MSG = 'Use `%<prefer>s` instead of ' \
-              '`%<first_method>s.%<second_method>s`.'.freeze
+              '`%<first_method>s.%<second_method>s`.'
         REVERSE_MSG = 'Use `reverse.%<prefer>s` instead of ' \
-                      '`%<first_method>s.%<second_method>s`.'.freeze
+                      '`%<first_method>s.%<second_method>s`.'
 
         def_node_matcher :detect_candidate?, <<-PATTERN
           {

--- a/lib/rubocop/cop/performance/double_start_end_with.rb
+++ b/lib/rubocop/cop/performance/double_start_end_with.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   str.end_with?(var1, var2)
       class DoubleStartEndWith < Cop
         MSG = 'Use `%<receiver>s.%<method>s(%<combined_args>s)` ' \
-              'instead of `%<original_code>s`.'.freeze
+              'instead of `%<original_code>s`.'
 
         def on_or(node)
           receiver,

--- a/lib/rubocop/cop/performance/end_with.rb
+++ b/lib/rubocop/cop/performance/end_with.rb
@@ -16,8 +16,8 @@ module RuboCop
       #   'abc'.end_with?('bc')
       class EndWith < Cop
         MSG = 'Use `String#end_with?` instead of a regex match anchored to ' \
-              'the end of the string.'.freeze
-        SINGLE_QUOTE = "'".freeze
+              'the end of the string.'
+        SINGLE_QUOTE = "'"
 
         def_node_matcher :redundant_regex?, <<-PATTERN
           {(send $!nil? {:match :=~ :match?} (regexp (str $#literal_at_end?) (regopt)))

--- a/lib/rubocop/cop/performance/fixed_size.rb
+++ b/lib/rubocop/cop/performance/fixed_size.rb
@@ -46,7 +46,7 @@ module RuboCop
       #   waldo.size
       #
       class FixedSize < Cop
-        MSG = 'Do not compute the size of statically sized objects.'.freeze
+        MSG = 'Do not compute the size of statically sized objects.'
 
         def_node_matcher :counter, <<-MATCHER
           (send ${array hash str sym} {:count :length :size} $...)

--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -17,10 +17,10 @@ module RuboCop
       class FlatMap < Cop
         include RangeHelp
 
-        MSG = 'Use `flat_map` instead of `%<method>s...%<flatten>s`.'.freeze
+        MSG = 'Use `flat_map` instead of `%<method>s...%<flatten>s`.'
         FLATTEN_MULTIPLE_LEVELS = ' Beware, `flat_map` only flattens 1 level ' \
                                   'and `flatten` can be used to flatten ' \
-                                  'multiple levels.'.freeze
+                                  'multiple levels.'
 
         def_node_matcher :flat_map_candidate?, <<-PATTERN
           (send (block $(send _ ${:collect :map}) ...) ${:flatten :flatten!} $...)

--- a/lib/rubocop/cop/performance/open_struct.rb
+++ b/lib/rubocop/cop/performance/open_struct.rb
@@ -29,7 +29,7 @@ module RuboCop
       #
       class OpenStruct < Cop
         MSG = 'Consider using `Struct` over `OpenStruct` ' \
-              'to optimize the performance.'.freeze
+              'to optimize the performance.'
 
         def_node_matcher :open_struct, <<-PATTERN
           (send (const {nil? cbase} :OpenStruct) :new ...)

--- a/lib/rubocop/cop/performance/range_include.rb
+++ b/lib/rubocop/cop/performance/range_include.rb
@@ -24,7 +24,7 @@ module RuboCop
       #
       #   ('a'..'z').cover?('yellow') # => true
       class RangeInclude < Cop
-        MSG = 'Use `Range#cover?` instead of `Range#include?`.'.freeze
+        MSG = 'Use `Range#cover?` instead of `Range#include?`.'
 
         # TODO: If we traced out assignments of variables to their uses, we
         # might pick up on a few more instances of this issue

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -23,11 +23,11 @@ module RuboCop
       #     yield 1, 2, 3
       #   end
       class RedundantBlockCall < Cop
-        MSG = 'Use `yield` instead of `%<argname>s.call`.'.freeze
-        YIELD = 'yield'.freeze
-        OPEN_PAREN = '('.freeze
-        CLOSE_PAREN = ')'.freeze
-        SPACE = ' '.freeze
+        MSG = 'Use `yield` instead of `%<argname>s.call`.'
+        YIELD = 'yield'
+        OPEN_PAREN = '('
+        CLOSE_PAREN = ')'
+        SPACE = ' '
 
         def_node_matcher :blockarg_def, <<-PATTERN
           {(def  _   (args ... (blockarg $_)) $_)

--- a/lib/rubocop/cop/performance/redundant_match.rb
+++ b/lib/rubocop/cop/performance/redundant_match.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   return value unless regex =~ 'str'
       class RedundantMatch < Cop
         MSG = 'Use `=~` in places where the `MatchData` returned by ' \
-              '`#match` will not be used.'.freeze
+              '`#match` will not be used.'
 
         # 'match' is a fairly generic name, so we don't flag it unless we see
         # a string or regexp literal on one side or the other

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -14,7 +14,7 @@ module RuboCop
         AREF_ASGN = '%<receiver>s[%<key>s] = %<value>s'
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
 
-        WITH_MODIFIER_CORRECTION = <<-RUBY.strip_indent
+        WITH_MODIFIER_CORRECTION = <<~RUBY
           %<keyword>s %<condition>s
           %<leading_space>s%<indent>s%<body>s
           %<leading_space>send

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -11,8 +11,8 @@ module RuboCop
       #   hash.merge!({'key' => 'value'})
       #   hash.merge!(a: 1, b: 2)
       class RedundantMerge < Cop
-        AREF_ASGN = '%<receiver>s[%<key>s] = %<value>s'.freeze
-        MSG = 'Use `%<prefer>s` instead of `%<current>s`.'.freeze
+        AREF_ASGN = '%<receiver>s[%<key>s] = %<value>s'
+        MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
 
         WITH_MODIFIER_CORRECTION = <<-RUBY.strip_indent
           %<keyword>s %<condition>s

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -82,7 +82,7 @@ module RuboCop
         TYPES_IMPLEMENTING_MATCH = %i[const regexp str sym].freeze
         MSG =
           'Use `match?` instead of `%<current>s` when `MatchData` ' \
-          'is not used.'.freeze
+          'is not used.'
 
         def_node_matcher :match_method?, <<-PATTERN
           {
@@ -106,7 +106,7 @@ module RuboCop
           regexp.to_regexp.named_captures.empty?
         end
 
-        MATCH_NODE_PATTERN = <<-PATTERN.freeze
+        MATCH_NODE_PATTERN = <<-PATTERN
           {
             #match_method?
             #match_operator?

--- a/lib/rubocop/cop/performance/reverse_each.rb
+++ b/lib/rubocop/cop/performance/reverse_each.rb
@@ -15,8 +15,8 @@ module RuboCop
       class ReverseEach < Cop
         include RangeHelp
 
-        MSG = 'Use `reverse_each` instead of `reverse.each`.'.freeze
-        UNDERSCORE = '_'.freeze
+        MSG = 'Use `reverse_each` instead of `reverse.each`.'
+        UNDERSCORE = '_'
 
         def_node_matcher :reverse_each?, <<-MATCHER
           (send $(send _ :reverse) :each)

--- a/lib/rubocop/cop/performance/size.rb
+++ b/lib/rubocop/cop/performance/size.rb
@@ -24,7 +24,7 @@ module RuboCop
       # TODO: Add advanced detection of variables that could
       # have been assigned to an array or a hash.
       class Size < Cop
-        MSG = 'Use `size` instead of `count`.'.freeze
+        MSG = 'Use `size` instead of `count`.'
 
         def on_send(node)
           return unless eligible_node?(node)
@@ -51,7 +51,7 @@ module RuboCop
         end
 
         def allowed_parent?(node)
-          node && node.block_type?
+          node&.block_type?
         end
 
         def array?(node)

--- a/lib/rubocop/cop/performance/start_with.rb
+++ b/lib/rubocop/cop/performance/start_with.rb
@@ -16,8 +16,8 @@ module RuboCop
       #   'abc'.start_with?('ab')
       class StartWith < Cop
         MSG = 'Use `String#start_with?` instead of a regex match anchored to ' \
-              'the beginning of the string.'.freeze
-        SINGLE_QUOTE = "'".freeze
+              'the beginning of the string.'
+        SINGLE_QUOTE = "'"
 
         def_node_matcher :redundant_regex?, <<-PATTERN
           {(send $!nil? {:match :=~ :match?} (regexp (str $#literal_at_start?) (regopt)))

--- a/lib/rubocop/cop/performance/string_replacement.rb
+++ b/lib/rubocop/cop/performance/string_replacement.rb
@@ -21,12 +21,12 @@ module RuboCop
       class StringReplacement < Cop
         include RangeHelp
 
-        MSG = 'Use `%<prefer>s` instead of `%<current>s`.'.freeze
+        MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
         DETERMINISTIC_REGEX = /\A(?:#{LITERAL_REGEX})+\Z/.freeze
-        DELETE = 'delete'.freeze
-        TR = 'tr'.freeze
-        BANG = '!'.freeze
-        SINGLE_QUOTE = "'".freeze
+        DELETE = 'delete'
+        TR = 'tr'
+        BANG = '!'
+        SINGLE_QUOTE = "'"
 
         def_node_matcher :string_replacement?, <<-PATTERN
           (send _ {:gsub :gsub!}

--- a/lib/rubocop/cop/performance/times_map.rb
+++ b/lib/rubocop/cop/performance/times_map.rb
@@ -19,8 +19,8 @@ module RuboCop
       #   end
       class TimesMap < Cop
         MESSAGE = 'Use `Array.new(%<count>s)` with a block ' \
-                  'instead of `.times.%<map_or_collect>s`'.freeze
-        MESSAGE_ONLY_IF = 'only if `%<count>s` is always 0 or more'.freeze
+                  'instead of `.times.%<map_or_collect>s`'
+        MESSAGE_ONLY_IF = 'only if `%<count>s` is always 0 or more'
 
         def on_send(node)
           check(node)

--- a/lib/rubocop/cop/performance/unfreeze_string.rb
+++ b/lib/rubocop/cop/performance/unfreeze_string.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         minimum_target_ruby_version 2.3
 
-        MSG = 'Use unary plus to get an unfrozen string literal.'.freeze
+        MSG = 'Use unary plus to get an unfrozen string literal.'
 
         def_node_matcher :dup_string?, <<-PATTERN
           (send {str dstr} :dup)

--- a/lib/rubocop/cop/performance/uri_default_parser.rb
+++ b/lib/rubocop/cop/performance/uri_default_parser.rb
@@ -15,7 +15,7 @@ module RuboCop
       #
       class UriDefaultParser < Cop
         MSG = 'Use `%<double_colon>sURI::DEFAULT_PARSER` instead of ' \
-              '`%<double_colon>sURI::Parser.new`.'.freeze
+              '`%<double_colon>sURI::Parser.new`.'
 
         def_node_matcher :uri_parser_new?, <<-PATTERN
           (send

--- a/lib/rubocop/performance/version.rb
+++ b/lib/rubocop/performance/version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Performance
     module Version
-      STRING = '1.2.0'.freeze
+      STRING = '1.2.0'
     end
   end
 end

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop-performance'
   s.version = RuboCop::Performance::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.3.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<-DESCRIPTION
     A collection of RuboCop cops to check for performance optimizations

--- a/spec/rubocop/cop/performance/caller_spec.rb
+++ b/spec/rubocop/cop/performance/caller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Performance::Caller do
 
   it 'registers an offense when :first is called on caller' do
     expect(caller.first).to eq(caller(1..1).first)
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       caller.first
       ^^^^^^^^^^^^ Use `caller(1..1).first` instead of `caller.first`.
     RUBY
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Performance::Caller do
 
   it 'registers an offense when :first is called on caller with 1' do
     expect(caller(1).first).to eq(caller(1..1).first)
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       caller(1).first
       ^^^^^^^^^^^^^^^ Use `caller(1..1).first` instead of `caller.first`.
     RUBY
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::Performance::Caller do
 
   it 'registers an offense when :first is called on caller with 2' do
     expect(caller(2).first).to eq(caller(2..2).first)
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       caller(2).first
       ^^^^^^^^^^^^^^^ Use `caller(2..2).first` instead of `caller.first`.
     RUBY
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::Performance::Caller do
 
   it 'registers an offense when :[] is called on caller' do
     expect(caller[1]).to eq(caller(2..2).first)
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       caller[1]
       ^^^^^^^^^ Use `caller(2..2).first` instead of `caller[1]`.
     RUBY
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::Performance::Caller do
 
   it 'registers an offense when :[] is called on caller with 1' do
     expect(caller(1)[1]).to eq(caller(2..2).first)
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       caller(1)[1]
       ^^^^^^^^^^^^ Use `caller(2..2).first` instead of `caller[1]`.
     RUBY
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::Performance::Caller do
 
   it 'registers an offense when :[] is called on caller with 2' do
     expect(caller(2)[1]).to eq(caller(3..3).first)
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       caller(2)[1]
       ^^^^^^^^^^^^ Use `caller(3..3).first` instead of `caller[1]`.
     RUBY
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::Performance::Caller do
 
   it 'registers an offense when :first is called on caller_locations also' do
     expect(caller_locations.first.to_s).to eq(caller_locations(1..1).first.to_s)
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       caller_locations.first
       ^^^^^^^^^^^^^^^^^^^^^^ Use `caller_locations(1..1).first` instead of `caller_locations.first`.
     RUBY
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::Performance::Caller do
 
   it 'registers an offense when :[] is called on caller_locations also' do
     expect(caller_locations[1].to_s).to eq(caller_locations(2..2).first.to_s)
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       caller_locations[1]
       ^^^^^^^^^^^^^^^^^^^ Use `caller_locations(2..2).first` instead of `caller_locations[1]`.
     RUBY

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   subject(:cop) { described_class.new }
 
   it 'allows case when without splat' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       case foo
       when 1
         bar
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'allows splat on a variable in the last when condition' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       case foo
       when 4
         foobar
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'allows multiple splat conditions on variables at the end' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       case foo
       when 4
         foobar
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'registers an offense for case when with a splat in the first condition' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       case foo
       when *cond
       ^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'registers an offense for case when with a splat without an else' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       case foo
       when *baz
       ^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'registers an offense for splat conditions in when then' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       case foo
       when *cond then bar
       ^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
 
   it 'registers an offense for a single when with splat expansion followed ' \
      'by another value' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       case foo
       when *Foo, Bar
       ^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
@@ -90,7 +90,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'registers an offense for multiple splat conditions at the beginning' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       case foo
       when *cond1
       ^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'registers an offense for multiple out of order splat conditions' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       case foo
       when *cond1
       ^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
@@ -126,7 +126,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'registers an offense for splat condition that do not appear at the end' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       case foo
       when *cond1
       ^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
@@ -147,7 +147,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'allows splat expansion on an array literal' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       case foo
       when *[1, 2]
         bar
@@ -160,7 +160,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'allows splat expansion on array literal as the last condition' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       case foo
       when *[1, 2]
         bar
@@ -170,7 +170,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
 
   it 'registers an offense for a splat on a variable that proceeds a splat ' \
      'on an array literal as the last condition' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       case foo
       when *cond
       ^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
@@ -182,7 +182,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'registers an offense when splat is part of the condition' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       case foo
       when cond1, *cond2
       ^^^^^^^^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
@@ -196,14 +196,14 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
   context 'autocorrect' do
     it 'corrects a single when with splat expansion followed by ' \
       'another value' do
-      source = <<-RUBY.strip_indent
+      source = <<~RUBY
         case foo
         when *Foo, Bar, Baz
           nil
         end
       RUBY
       new_source = autocorrect_source(source)
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when Bar, Baz, *Foo
           nil
@@ -213,7 +213,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
 
     it 'corrects a when with splat expansion followed by another value ' \
       'when there are multiple whens' do
-      source = <<-RUBY.strip_indent
+      source = <<~RUBY
         case foo
         when *Foo, Bar
           nil
@@ -222,7 +222,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
         end
       RUBY
       new_source = autocorrect_source(source)
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when FooBar
           1
@@ -234,7 +234,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
 
     it 'corrects a when with multiple out of order splat expansions ' \
       'followed by other values when there are multiple whens' do
-      source = <<-RUBY.strip_indent
+      source = <<~RUBY
         case foo
         when *Foo, Bar, *Baz, Qux
           nil
@@ -243,7 +243,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
         end
       RUBY
       new_source = autocorrect_source(source)
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when FooBar
           1
@@ -254,7 +254,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'moves a single splat condition to the end of the when conditions' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         case foo
         when *cond
           bar
@@ -263,7 +263,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
         end
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when 3
           baz
@@ -274,7 +274,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'moves multiple splat condition to the end of the when conditions' do
-      new_source = autocorrect_source_with_loop(<<-RUBY.strip_indent)
+      new_source = autocorrect_source_with_loop(<<~RUBY)
         case foo
         when *cond1
           bar
@@ -285,7 +285,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
         end
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when 5
           baz
@@ -299,7 +299,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
 
     it 'moves multiple out of order splat condition to the end ' \
        'of the when conditions' do
-      new_source = autocorrect_source_with_loop(<<-RUBY.strip_indent)
+      new_source = autocorrect_source_with_loop(<<~RUBY)
         case foo
         when *cond1
           bar
@@ -312,7 +312,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
         end
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when 3
           doo
@@ -327,14 +327,14 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects splat condition when using when then' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         case foo
         when *cond then bar
         when 4 then baz
         end
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when 4 then baz
         when *cond then bar
@@ -343,7 +343,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects nested case when statements' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         def check
           case foo
           when *cond
@@ -354,7 +354,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
         end
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         def check
           case foo
           when 3
@@ -367,7 +367,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects splat on a variable and leaves an array literal alone' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         case foo
         when *cond
           bar
@@ -376,7 +376,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
         end
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when *[1, 2]
           baz
@@ -387,7 +387,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects a splat as part of the condition' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         case foo
         when cond1, *cond2
           bar
@@ -396,7 +396,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
         end
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when cond3
           baz
@@ -407,7 +407,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects an array followed by splat in the same condition' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         case foo
         when *[cond1, cond2], *cond3
           bar
@@ -416,7 +416,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
         end
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when cond4
           baz
@@ -427,7 +427,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects a splat followed by array in the same condition' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         case foo
         when *cond1, *[cond2, cond3]
           bar
@@ -436,7 +436,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
         end
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         case foo
         when cond4
           baz

--- a/spec/rubocop/cop/performance/casecmp_spec.rb
+++ b/spec/rubocop/cop/performance/casecmp_spec.rb
@@ -115,14 +115,14 @@ RSpec.describe RuboCop::Cop::Performance::Casecmp do
     end
 
     it "doesn't report an offense for variable == str.#{selector}" do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         var = "a"
         var == str.#{selector}
       RUBY
     end
 
     it "doesn't report an offense for str.#{selector} == variable" do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         var = "a"
         str.#{selector} == var
       RUBY

--- a/spec/rubocop/cop/performance/compare_with_block_spec.rb
+++ b/spec/rubocop/cop/performance/compare_with_block_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::Performance::CompareWithBlock do
     end
 
     it "autocorrects array.#{method} do |a, b| a.foo <=> b.foo end" do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         array.#{method} do |a, b|
           a.foo <=> b.foo
         end

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -53,19 +53,19 @@ RSpec.describe RuboCop::Cop::Performance::Count do
     end
 
     it "allows usage of #{selector}...count with a block on an array" do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         [1, 2, 3].#{selector} { |e| e.odd? }.count { |e| e > 2 }
       RUBY
     end
 
     it "allows usage of #{selector}...count with a block on a hash" do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         {a: 1, b: 2}.#{selector} { |e| e == :a }.count { |e| e > 2 }
       RUBY
     end
 
     it "registers an offense for #{selector} with params instead of a block" do
-      inspect_source(<<-RUBY.strip_indent)
+      inspect_source(<<~RUBY)
         Data = Struct.new(:value)
         array = [Data.new(2), Data.new(3), Data.new(2)]
         puts array.#{selector}(&:value).count
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::Performance::Count do
 
     it "registers an offense for #{selector}(&:something).count " \
        'when called as an instance method on its own class' do
-      source = <<-RUBY.strip_indent
+      source = <<~RUBY
         class A < Array
           def count(&block)
             #{selector}(&block).count
@@ -128,7 +128,7 @@ RSpec.describe RuboCop::Cop::Performance::Count do
     end
 
     it 'allows usage of select with multiple strings' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         Model.select('field AS field_one', 'other AS field_two').count
       RUBY
     end
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::Performance::Count do
   end
 
   it 'allows usage of count on an interstitial method called on select' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       Data = Struct.new(:value)
       array = [Data.new(2), Data.new(3), Data.new(2)]
       puts array.select(&:value).uniq.count
@@ -164,7 +164,7 @@ RSpec.describe RuboCop::Cop::Performance::Count do
 
   it 'allows usage of count on an interstitial method with blocks ' \
      'called on select' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       Data = Struct.new(:value)
       array = [Data.new(2), Data.new(3), Data.new(2)]
       array.select(&:value).uniq { |v| v > 2 }.count
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::Cop::Performance::Count do
   end
 
   it 'allows usage of size called on an assigned variable' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       nodes = [1]
       nodes.size
     RUBY
@@ -215,7 +215,7 @@ RSpec.describe RuboCop::Cop::Performance::Count do
       end
 
       it 'select...size when select has parameters' do
-        source = <<-RUBY.strip_indent
+        source = <<~RUBY
           Data = Struct.new(:value)
           array = [Data.new(2), Data.new(3), Data.new(2)]
           puts array.select(&:value).size
@@ -224,7 +224,7 @@ RSpec.describe RuboCop::Cop::Performance::Count do
         new_source = autocorrect_source(source)
 
         expect(new_source)
-          .to eq(<<-RUBY.strip_indent)
+          .to eq(<<~RUBY)
             Data = Struct.new(:value)
             array = [Data.new(2), Data.new(3), Data.new(2)]
             puts array.count(&:value)
@@ -259,7 +259,7 @@ RSpec.describe RuboCop::Cop::Performance::Count do
       end
 
       it 'reject...size when select has parameters' do
-        source = <<-RUBY.strip_indent
+        source = <<~RUBY
           Data = Struct.new(:value)
           array = [Data.new(2), Data.new(3), Data.new(2)]
           puts array.reject(&:value).size

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
     end
 
     it "registers an offense when first is called on multiline #{method}" do
-      inspect_source(<<-RUBY.strip_indent)
+      inspect_source(<<~RUBY)
         [1, 2, 3].#{method} do |i|
           i % 2 == 0
         end.first
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
     end
 
     it "registers an offense when last is called on multiline #{method}" do
-      inspect_source(<<-RUBY.strip_indent)
+      inspect_source(<<~RUBY)
         [1, 2, 3].#{method} do |i|
           i % 2 == 0
         end.last
@@ -151,14 +151,14 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
           end
 
           it "corrects #{method}.first to #{preferred_method} (multiline)" do
-            source = <<-RUBY.strip_indent
+            source = <<~RUBY
               [1, 2, 3].#{method} do |i|
                 i % 2 == 0
               end.first
             RUBY
             new_source = autocorrect_source(source)
 
-            expect(new_source).to eq(<<-RUBY.strip_indent)
+            expect(new_source).to eq(<<~RUBY)
               [1, 2, 3].#{preferred_method} do |i|
                 i % 2 == 0
               end
@@ -167,7 +167,7 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
 
           it "corrects #{method}.last to reverse.#{preferred_method} " \
              '(multiline)' do
-            source = <<-RUBY.strip_indent
+            source = <<~RUBY
               [1, 2, 3].#{method} do |i|
                 i % 2 == 0
               end.last
@@ -175,7 +175,7 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
             new_source = autocorrect_source(source)
 
             expect(new_source)
-              .to eq(<<-RUBY.strip_indent)
+              .to eq(<<~RUBY)
                 [1, 2, 3].reverse.#{preferred_method} do |i|
                   i % 2 == 0
                 end
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
 
           it "corrects multiline #{method} to #{preferred_method} " \
              "with 'first' on the last line" do
-            source = <<-RUBY.strip_indent
+            source = <<~RUBY
               [1, 2, 3].#{method} { true }
               .first['x']
             RUBY
@@ -196,7 +196,7 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
 
           it "corrects multiline #{method} to #{preferred_method} " \
              "with 'first' on the last line (short syntax)" do
-            source = <<-RUBY.strip_indent
+            source = <<~RUBY
               [1, 2, 3].#{method}(&:blank?)
               .first['x']
             RUBY

--- a/spec/rubocop/cop/performance/double_start_end_with_spec.rb
+++ b/spec/rubocop/cop/performance/double_start_end_with_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith do
 
         context 'one of the parameters of the second call is not pure' do
           it "doesn't register an offense" do
-            expect_no_offenses(<<-RUBY.strip_indent)
+            expect_no_offenses(<<~RUBY)
               x.starts_with?(a, "b") || x.starts_with?(C, d)
             RUBY
           end

--- a/spec/rubocop/cop/performance/fixed_size_spec.rb
+++ b/spec/rubocop/cop/performance/fixed_size_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Performance::FixedSize do
       end
 
       it "accepts calling #{method} on a variable " do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           foo = "abc"
           foo.#{method}
         RUBY
@@ -133,7 +133,7 @@ RSpec.describe RuboCop::Cop::Performance::FixedSize do
       end
 
       it "accepts calling #{method} on array that is set to a variable" do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           foo = [1, 2, 3]
           foo.#{method}
         RUBY
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Cop::Performance::FixedSize do
       end
 
       it "accepts calling #{method} on a hash set to a variable" do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           foo = {a: 1, b: 2}
           foo.#{method}
         RUBY

--- a/spec/rubocop/cop/performance/inefficient_hash_search_spec.rb
+++ b/spec/rubocop/cop/performance/inefficient_hash_search_spec.rb
@@ -8,48 +8,48 @@ RSpec.describe RuboCop::Cop::Performance::InefficientHashSearch do
     let(:expected_value_method) { expected == :short ? 'value?' : 'has_value?' }
 
     it 'registers an offense when a hash literal receives `keys.include?`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         { a: 1 }.keys.include? 1
         ^^^^^^^^^^^^^^^^^^^^^^^^ Use `##{expected_key_method}` instead of `#keys.include?`.
       RUBY
     end
 
     it 'registers an offense when an existing hash receives `keys.include?`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         h = { a: 1 }; h.keys.include? 1
                       ^^^^^^^^^^^^^^^^^ Use `##{expected_key_method}` instead of `#keys.include?`.
       RUBY
     end
 
     it 'registers an offense when a hash literal receives `values.include?`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         { a: 1 }.values.include? 1
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `##{expected_value_method}` instead of `#values.include?`.
       RUBY
     end
 
     it 'registers an offense when a hash variable receives `values.include?`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         h = { a: 1 }; h.values.include? 1
                       ^^^^^^^^^^^^^^^^^^^ Use `##{expected_value_method}` instead of `#values.include?`.
       RUBY
     end
 
     it 'finds no offense when a `keys` array variable receives `include?`' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         h = { a: 1 }; keys = h.keys ; keys.include? 1
       RUBY
     end
 
     it 'finds no offense when a `values` array variable receives `include?` ' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         h = { a: 1 }; values = h.values ; values.include? 1
       RUBY
     end
 
     it 'does not register an offense when `keys` method defined by itself ' \
        'and `include?` method are method chaining' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         def my_include?(key)
           keys.include?(key)
         end

--- a/spec/rubocop/cop/performance/open_struct_spec.rb
+++ b/spec/rubocop/cop/performance/open_struct_spec.rb
@@ -6,21 +6,21 @@ RSpec.describe RuboCop::Cop::Performance::OpenStruct do
   let(:config) { RuboCop::Config.new }
 
   it 'registers an offense for OpenStruct.new' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       OpenStruct.new(key: "value")
                  ^^^ Consider using `Struct` over `OpenStruct` to optimize the performance.
     RUBY
   end
 
   it 'registers an offense for a fully qualified ::OpenStruct.new' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       ::OpenStruct.new(key: "value")
                    ^^^ Consider using `Struct` over `OpenStruct` to optimize the performance.
     RUBY
   end
 
   it 'does not register offense for Struct' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       MyStruct = Struct.new(:key)
       MyStruct.new('value')
     RUBY

--- a/spec/rubocop/cop/performance/range_include_spec.rb
+++ b/spec/rubocop/cop/performance/range_include_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::Performance::RangeInclude do
   end
 
   it 'formats the error message correctly for (a..b).include? 1' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       (a..b).include? 1
              ^^^^^^^^ Use `Range#cover?` instead of `Range#include?`.
     RUBY

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   subject(:cop) { described_class.new }
 
   it 'autocorrects block.call without arguments' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<~RUBY)
       def method(&block)
         block.call
       end
     RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect(new_source).to eq(<<~RUBY)
       def method(&block)
         yield
       end
@@ -17,12 +17,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'autocorrects block.call with empty parentheses' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<~RUBY)
       def method(&block)
         block.call()
       end
     RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect(new_source).to eq(<<~RUBY)
       def method(&block)
         yield
       end
@@ -30,12 +30,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'autocorrects block.call with arguments' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<~RUBY)
       def method(&block)
         block.call 1, 2
       end
     RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect(new_source).to eq(<<~RUBY)
       def method(&block)
         yield 1, 2
       end
@@ -43,13 +43,13 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'autocorrects multiple occurrences of block.call with arguments' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<~RUBY)
       def method(&block)
         block.call 1
         block.call 2
       end
     RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect(new_source).to eq(<<~RUBY)
       def method(&block)
         yield 1
         yield 2
@@ -58,12 +58,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'autocorrects even when block arg has a different name' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<~RUBY)
       def method(&func)
         func.call
       end
     RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect(new_source).to eq(<<~RUBY)
       def method(&func)
         yield
       end
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'accepts a block that is not `call`ed' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def method(&block)
        something.call
       end
@@ -79,14 +79,14 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'accepts an empty method body' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def method(&block)
       end
     RUBY
   end
 
   it 'accepts another block being passed as the only arg' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def method(&block)
         block.call(&some_proc)
       end
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'accepts another block being passed along with other args' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def method(&block)
         block.call(1, &some_proc)
       end
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'accepts another block arg in at least one occurrence of block.call' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def method(&block)
         block.call(1, &some_proc)
         block.call(2)
@@ -111,7 +111,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'accepts an optional block that is defaulted' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def method(&block)
         block ||= ->(i) { puts i }
         block.call(1)
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'accepts an optional block that is overridden' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def method(&block)
         block = ->(i) { puts i }
         block.call(1)
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'formats the error message for func.call(1) correctly' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       def method(&func)
         func.call(1)
         ^^^^^^^^^^^^ Use `yield` instead of `func.call`.
@@ -138,13 +138,13 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'autocorrects using parentheses when block.call uses parentheses' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<~RUBY)
       def method(&block)
         block.call(a, b)
       end
     RUBY
 
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect(new_source).to eq(<<~RUBY)
       def method(&block)
         yield(a, b)
       end
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
 
   it 'autocorrects when the result of the call is used in a scope that ' \
      'requires parentheses' do
-    source = <<-RUBY.strip_indent
+    source = <<~RUBY
       def method(&block)
         each_with_object({}) do |(key, value), acc|
           acc.merge!(block.call(key) => rhs[value])
@@ -163,7 +163,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall do
 
     new_source = autocorrect_source(source)
 
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect(new_source).to eq(<<~RUBY)
       def method(&block)
         each_with_object({}) do |(key, value), acc|
           acc.merge!(yield(key) => rhs[value])

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'autocorrects .match in while condition' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<~RUBY)
       while str.match(/regex/)
         do_something
       end
     RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect(new_source).to eq(<<~RUBY)
       while str =~ /regex/
         do_something
       end
@@ -36,12 +36,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'autocorrects .match in until condition' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<~RUBY)
       until str.match(/regex/)
         do_something
       end
     RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect(new_source).to eq(<<~RUBY)
       until str =~ /regex/
         do_something
       end
@@ -49,13 +49,13 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'autocorrects .match in method body (but not tail position)' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<~RUBY)
       def method(str)
         str.match(/regex/)
         true
       end
     RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect(new_source).to eq(<<~RUBY)
       def method(str)
         str =~ /regex/
         true
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch do
 
   it 'does not register an error when return value of .match is passed ' \
      'to another method' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def method(str)
        something(str.match(/regex/))
       end
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch do
 
   it 'does not register an error when return value of .match is stored in an ' \
      'instance variable' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def method(str)
        @var = str.match(/regex/)
        true
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch do
 
   it 'does not register an error when return value of .match is returned from' \
      ' surrounding method' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def method(str)
        str.match(/regex/)
       end
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'does not register an offense when match has a block' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       /regex/.match(str) do |m|
         something(m)
       end
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'formats error message correctly for something if str.match(/regex/)' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       something if str.match(/regex/)
                    ^^^^^^^^^^^^^^^^^^ Use `=~` in places where the `MatchData` returned by `#match` will not be used.
     RUBY

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
   context 'when receiver is a local variable' do
     it 'autocorrects hash.merge!(a: 1, b: 2)' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         hash = {}
         hash.merge!(a: 1, b: 2)
       RUBY
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         hash = {}
         hash[:a] = 1
         hash[:b] = 2
@@ -48,14 +48,14 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
   context 'when any argument is a double splat' do
     it 'does not register an offense when the only argument is a' \
        'double splat' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         foo.merge!(**bar)
       RUBY
     end
 
     it 'does not register an offense when there are multiple arguments ' \
        'and at least one is a double splat' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         foo.merge!(baz: qux, **bar)
       RUBY
     end
@@ -63,14 +63,14 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
   context 'when internal to each_with_object' do
     it 'autocorrects when the receiver is the object being built' do
-      source = <<-RUBY.strip_indent
+      source = <<~RUBY
         foo.each_with_object({}) do |f, hash|
           hash.merge!(a: 1, b: 2)
         end
       RUBY
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         foo.each_with_object({}) do |f, hash|
           hash[:a] = 1
           hash[:b] = 2
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
     it 'autocorrects when the receiver is the object being built when ' \
        'merge! is the last statement' do
-      source = <<-RUBY.strip_indent
+      source = <<~RUBY
         foo.each_with_object({}) do |f, hash|
           some_method
           hash.merge!(a: 1, b: 2)
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
       RUBY
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         foo.each_with_object({}) do |f, hash|
           some_method
           hash[:a] = 1
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
     it 'autocorrects when the receiver is the object being built when ' \
        'merge! is not the last statement' do
-      source = <<-RUBY.strip_indent
+      source = <<~RUBY
         foo.each_with_object({}) do |f, hash|
           hash.merge!(a: 1, b: 2)
           why_are_you_doing_this?
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
       RUBY
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         foo.each_with_object({}) do |f, hash|
           hash[:a] = 1
           hash[:b] = 2
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
     it 'does not register an offense when merge! is being assigned inside ' \
        'each_with_object' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         foo.each_with_object({}) do |f, hash|
           changes = hash.merge!(a: 1, b: 2)
           why_are_you_doing_this?
@@ -128,14 +128,14 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
     it 'autocorrects when receiver uses element reference to the object ' \
        'built by each_with_object' do
-      source = <<-RUBY.strip_indent
+      source = <<~RUBY
         foo.each_with_object(bar) do |f, hash|
           hash[:a].merge!(b: "")
         end
       RUBY
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         foo.each_with_object(bar) do |f, hash|
           hash[:a][:b] = ""
         end
@@ -144,14 +144,14 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
     it 'autocorrects when receiver uses multiple element references to the ' \
        'object built by each_with_object' do
-      source = <<-RUBY.strip_indent
+      source = <<~RUBY
         foo.each_with_object(bar) do |f, hash|
           hash[:a][:b].merge!(c: "")
         end
       RUBY
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         foo.each_with_object(bar) do |f, hash|
           hash[:a][:b][:c] = ""
         end
@@ -160,14 +160,14 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
     it 'autocorrects merge! called on any method on the object built ' \
        'by each_with_object' do
-      source = <<-RUBY.strip_indent
+      source = <<~RUBY
         foo.each_with_object(bar) do |f, hash|
           hash.bar.merge!(c: "")
         end
       RUBY
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         foo.each_with_object(bar) do |f, hash|
           hash.bar[:c] = ""
         end
@@ -179,12 +179,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
     context "when there is a modifier #{kw}, and more than 1 pair" do
       it "autocorrects it to an #{kw} block" do
         new_source = autocorrect_source(
-          <<-RUBY.strip_indent
+          <<~RUBY
             hash = {}
             hash.merge!(a: 1, b: 2) #{kw} condition1 && condition2
           RUBY
         )
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect(new_source).to eq(<<~RUBY)
           hash = {}
           #{kw} condition1 && condition2
             hash[:a] = 1
@@ -196,14 +196,14 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
       context 'when original code was indented' do
         it 'maintains proper indentation' do
           new_source = autocorrect_source(
-            <<-RUBY.strip_indent
+            <<~RUBY
               hash = {}
               begin
                 hash.merge!(a: 1, b: 2) #{kw} condition1
               end
             RUBY
           )
-          expect(new_source).to eq(<<-RUBY.strip_indent)
+          expect(new_source).to eq(<<~RUBY)
             hash = {}
             begin
               #{kw} condition1
@@ -219,13 +219,13 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
   context 'when code is indented, and there is more than 1 pair' do
     it 'indents the autocorrected code properly' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         hash = {}
         begin
           hash.merge!(a: 1, b: 2)
         end
       RUBY
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         hash = {}
         begin
           hash[:a] = 1
@@ -236,14 +236,14 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
   end
 
   it "doesn't register an error when return value is used" do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       variable = hash.merge!(a: 1)
       puts variable
     RUBY
   end
 
   it 'formats the error message correctly for hash.merge!(a: 1)' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       hash.merge!(a: 1)
       ^^^^^^^^^^^^^^^^^ Use `hash[:a] = 1` instead of `hash.merge!(a: 1)`.
     RUBY
@@ -255,7 +255,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
     end
 
     it "doesn't register errors for multi-value hash merges" do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         hash = {}
         hash.merge!(a: 1, b: 2)
       RUBY

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
   subject(:cop) { described_class.new }
 
   it 'registers an offense when each is called on reverse' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       [1, 2, 3].reverse.each { |e| puts e }
                 ^^^^^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
     RUBY
   end
 
   it 'registers an offense when each is called on reverse on a variable' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       arr = [1, 2, 3]
       arr.reverse.each { |e| puts e }
           ^^^^^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
   end
 
   it 'registers an offense when each is called on reverse on a method call' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       def arr
         [1, 2, 3]
       end
@@ -45,19 +45,19 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
     end
 
     it 'corrects reverse.each to reverse_each on a variable' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         arr = [1, 2]
         arr.reverse.each { |e| puts e }
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         arr = [1, 2]
         arr.reverse_each { |e| puts e }
       RUBY
     end
 
     it 'corrects reverse.each to reverse_each on a method call' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         def arr
           [1, 2]
         end
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
         arr.reverse.each { |e| puts e }
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         def arr
           [1, 2]
         end

--- a/spec/rubocop/cop/performance/size_spec.rb
+++ b/spec/rubocop/cop/performance/size_spec.rb
@@ -15,21 +15,21 @@ RSpec.describe RuboCop::Cop::Performance::Size do
 
   describe 'on array' do
     it 'registers an offense when calling count' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         [1, 2, 3].count
                   ^^^^^ Use `size` instead of `count`.
       RUBY
     end
 
     it 'registers an offense when calling count on to_a' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         (1..3).to_a.count
                     ^^^^^ Use `size` instead of `count`.
       RUBY
     end
 
     it 'registers an offense when calling count on Array[]' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         Array[*1..5].count
                      ^^^^^ Use `size` instead of `count`.
       RUBY
@@ -76,21 +76,21 @@ RSpec.describe RuboCop::Cop::Performance::Size do
 
   describe 'on hash' do
     it 'registers an offense when calling count' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         {a: 1, b: 2, c: 3}.count
                            ^^^^^ Use `size` instead of `count`.
       RUBY
     end
 
     it 'registers an offense when calling count on to_h' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         [[:foo, :bar], [1, 2]].to_h.count
                                     ^^^^^ Use `size` instead of `count`.
       RUBY
     end
 
     it 'registers an offense when calling count on Hash[]' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         Hash[*('a'..'z')].count
                           ^^^^^ Use `size` instead of `count`.
       RUBY

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -14,21 +14,21 @@ RSpec.describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'accepts the first param being a variable' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           regex = /a/
           'abc'.#{method}(regex, '1')
         RUBY
       end
 
       it 'accepts the second param being a variable' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           replacement = 'e'
           'abc'.#{method}('abc', replacement)
         RUBY
       end
 
       it 'accepts the both params being a variables' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           regex = /a/
           replacement = 'e'
           'abc'.#{method}(regex, replacement)
@@ -44,14 +44,14 @@ RSpec.describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'accepts a pattern with string interpolation' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           foo = 'a'
           'abc'.#{method}(\"\#{foo}\", '1')
         RUBY
       end
 
       it 'accepts a replacement with string interpolation' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           foo = '1'
           'abc'.#{method}('a', \"\#{foo}\")
         RUBY
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::Performance::StringReplacement do
   describe 'deterministic regex' do
     describe 'regex literal' do
       it 'registers an offense when using space' do
-        expect_offense(<<-RUBY.strip_indent)
+        expect_offense(<<~RUBY)
           'abc'.gsub(/ /, '')
                 ^^^^^^^^^^^^^ Use `delete` instead of `gsub`.
         RUBY
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'registers an offense when using %r notation' do
-        expect_offense(<<-RUBY.strip_indent)
+        expect_offense(<<~RUBY)
           '/abc'.gsub(%r{a}, 'd')
                  ^^^^^^^^^^^^^^^^ Use `tr` instead of `gsub`.
         RUBY
@@ -139,21 +139,21 @@ RSpec.describe RuboCop::Cop::Performance::StringReplacement do
 
     describe 'regex constructor' do
       it 'registers an offense when only using word characters' do
-        expect_offense(<<-RUBY.strip_indent)
+        expect_offense(<<~RUBY)
           'abc'.gsub(Regexp.new('b'), '2')
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tr` instead of `gsub`.
         RUBY
       end
 
       it 'registers an offense when regex is built from regex' do
-        expect_offense(<<-RUBY.strip_indent)
+        expect_offense(<<~RUBY)
           'abc'.gsub(Regexp.new(/b/), '2')
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tr` instead of `gsub`.
         RUBY
       end
 
       it 'registers an offense when using compile' do
-        expect_offense(<<-RUBY.strip_indent)
+        expect_offense(<<~RUBY)
           '123'.gsub(Regexp.compile('1'), 'a')
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tr` instead of `gsub`.
         RUBY
@@ -211,21 +211,21 @@ RSpec.describe RuboCop::Cop::Performance::StringReplacement do
     end
 
     it 'allows regex literal containing interpolations' do
-      expect_no_offenses(<<-'RUBY'.strip_indent)
+      expect_no_offenses(<<~'RUBY')
         foo = 'a'
         "abc".gsub(/#{foo}/, "d")
       RUBY
     end
 
     it 'allows regex constructor containing a string with interpolations' do
-      expect_no_offenses(<<-'RUBY'.strip_indent)
+      expect_no_offenses(<<~'RUBY')
         foo = 'a'
         "abc".gsub(Regexp.new("#{foo}"), "d")
       RUBY
     end
 
     it 'allows regex constructor containing regex with interpolations' do
-      expect_no_offenses(<<-'RUBY'.strip_indent)
+      expect_no_offenses(<<~'RUBY')
         foo = 'a'
         "abc".gsub(Regexp.new(/#{foo}/), "d")
       RUBY
@@ -234,7 +234,7 @@ RSpec.describe RuboCop::Cop::Performance::StringReplacement do
 
   it 'registers an offense when the pattern has non deterministic regex ' \
      'as a string' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       'a + c'.gsub('+', '-')
               ^^^^^^^^^^^^^^ Use `tr` instead of `gsub`.
     RUBY
@@ -242,7 +242,7 @@ RSpec.describe RuboCop::Cop::Performance::StringReplacement do
 
   it 'registers an offense when using gsub to find and replace ' \
      'a single character' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       'abc'.gsub('a', '1')
             ^^^^^^^^^^^^^^ Use `tr` instead of `gsub`.
     RUBY
@@ -250,14 +250,14 @@ RSpec.describe RuboCop::Cop::Performance::StringReplacement do
 
   it 'registers an offense when using gsub! to find and replace ' \
      'a single character ' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       'abc'.gsub!('a', '1')
             ^^^^^^^^^^^^^^^ Use `tr!` instead of `gsub!`.
     RUBY
   end
 
   it 'registers an offense for gsub! when deleting one characters' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       'abc'.gsub!('a', '')
             ^^^^^^^^^^^^^^ Use `delete!` instead of `gsub!`.
     RUBY

--- a/spec/rubocop/cop/performance/unfreeze_string_spec.rb
+++ b/spec/rubocop/cop/performance/unfreeze_string_spec.rb
@@ -5,21 +5,21 @@ RSpec.describe RuboCop::Cop::Performance::UnfreezeString, :config do
 
   context 'TargetRubyVersion >= 2.3', :ruby23 do
     it 'registers an offense for an empty string with `.dup`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         "".dup
         ^^^^^^ Use unary plus to get an unfrozen string literal.
       RUBY
     end
 
     it 'registers an offense for a string with `.dup`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         "foo".dup
         ^^^^^^^^^ Use unary plus to get an unfrozen string literal.
       RUBY
     end
 
     it 'registers an offense for a heredoc with `.dup`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         <<TEXT.dup
         ^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
           foo
@@ -30,47 +30,47 @@ RSpec.describe RuboCop::Cop::Performance::UnfreezeString, :config do
 
     it 'registers an offense for a string that contains a string' \
        'interpolation with `.dup`' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         "foo#{bar}baz".dup
         ^^^^^^^^^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
       RUBY
     end
 
     it 'registers an offense for `String.new`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         String.new
         ^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
       RUBY
     end
 
     it 'registers an offense for `String.new` with an empty string' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         String.new('')
         ^^^^^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
       RUBY
     end
 
     it 'registers an offense for `String.new` with a string' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         String.new('foo')
         ^^^^^^^^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
       RUBY
     end
 
     it 'accepts an empty string with unary plus operator' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         +""
       RUBY
     end
 
     it 'accepts a string with unary plus operator' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         +"foobar"
       RUBY
     end
 
     it 'accepts `String.new` with capacity option' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         String.new(capacity: 100)
       RUBY
     end

--- a/spec/rubocop/cop/performance/uri_default_parser_spec.rb
+++ b/spec/rubocop/cop/performance/uri_default_parser_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe RuboCop::Cop::Performance::UriDefaultParser do
   let(:config) { RuboCop::Config.new }
 
   it 'registers an offense when using `URI::Parser.new`' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       URI::Parser.new.make_regexp
       ^^^^^^^^^^^^^^^ Use `URI::DEFAULT_PARSER` instead of `URI::Parser.new`.
     RUBY
   end
 
   it 'registers an offense when using `::URI::Parser.new`' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       ::URI::Parser.new.make_regexp
       ^^^^^^^^^^^^^^^^^ Use `::URI::DEFAULT_PARSER` instead of `::URI::Parser.new`.
     RUBY

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -19,7 +19,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     content = h2(cop.cop_name)
     content << properties(config, cop)
     content << "#{description}\n"
-    content << examples(examples_objects) if examples_objects.count > 0
+    content << examples(examples_objects) if examples_objects.count.positive?
     content << configurations(pars)
     content << references(config, cop)
     content
@@ -57,27 +57,27 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   # rubocop:enable Metrics/MethodLength
 
   def h2(title)
-    content = "\n".dup
+    content = +"\n"
     content << "## #{title}\n"
     content << "\n"
     content
   end
 
   def h3(title)
-    content = "\n".dup
+    content = +"\n"
     content << "### #{title}\n"
     content << "\n"
     content
   end
 
   def h4(title)
-    content = "#### #{title}\n".dup
+    content = +"#### #{title}\n"
     content << "\n"
     content
   end
 
   def code_example(ruby_code)
-    content = "```ruby\n".dup
+    content = +"```ruby\n"
     content << ruby_code.text
                .gsub('@good', '# good').gsub('@bad', '# bad').strip
     content << "\n```\n"
@@ -166,7 +166,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     end
     return if selected_cops.empty?
 
-    content = "# #{department}\n".dup
+    content = +"# #{department}\n"
     selected_cops.each do |cop|
       content << print_cop_with_doc(cop, config)
     end
@@ -204,7 +204,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
     type_title = department[0].upcase + department[1..-1]
     filename = "cops_#{department.downcase}.md"
-    content = "#### Department [#{type_title}](#{filename})\n\n".dup
+    content = +"#### Department [#{type_title}](#{filename})\n\n"
     selected_cops.each do |cop|
       anchor = cop.cop_name.sub('/', '').downcase
       content << "* [#{cop.cop_name}](#{filename}##{anchor})\n"
@@ -217,7 +217,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   def print_table_of_contents(cops)
     path = "#{Dir.pwd}/manual/cops.md"
     original = File.read(path)
-    content = "<!-- START_COP_LIST -->\n".dup
+    content = +"<!-- START_COP_LIST -->\n"
 
     content << table_contents(cops)
 


### PR DESCRIPTION
Ruby 2.2 has been EOL’ed for a while, and RuboCop just merged in a PR to drop Ruby 2.2 support. I don’t think it makes sense for RuboCop-Performance to support Ruby 2.2 now.

The 1st commit changes the Ruby version in gemspec and .rubocop.yml, and fixes the cop offenses that follows.

The 2nd commit changes all use of `strip_indent` (a utility method that is implemented in RuboCop, but might not be forever) to use “squiggly heredocs” (a Ruby 2.3 feature) instead.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
