### PR TITLE
Fix `Performance/FixedSize` to accept const assign with some operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#54](https://github.com/rubocop-hq/rubocop-performance/issues/54): Fix `Performance/FixedSize` to accept const assign with some operation. ([@tejasbubane][])
+
 ## 1.3.0 (2019-05-13)
 
 ### Bug fixes
@@ -35,3 +39,4 @@
 [@koic]: https://github.com/koic
 [@bquorning]: https://github.com/bquorning
 [@dduugg]: https://github.com/dduugg
+[@tejasbubane]: https://github.com/tejasbubane

--- a/lib/rubocop/cop/performance/fixed_size.rb
+++ b/lib/rubocop/cop/performance/fixed_size.rb
@@ -53,7 +53,7 @@ module RuboCop
         MATCHER
 
         def on_send(node)
-          return if allowed_parent?(node.parent)
+          return if node.ancestors.any? { |ancestor| allowed_parent?(ancestor) }
 
           counter(node) do |var, arg|
             return if allowed_variable?(var) || allowed_argument?(arg)

--- a/spec/rubocop/cop/performance/fixed_size_spec.rb
+++ b/spec/rubocop/cop/performance/fixed_size_spec.rb
@@ -71,6 +71,11 @@ RSpec.describe RuboCop::Cop::Performance::FixedSize do
         expect_no_offenses("CONST = %q(a).#{method}")
       end
 
+      it "accepts calling #{method} on a %q string that is assigned to " \
+         'a constant along with some arithmetic operations' do
+        expect_no_offenses("CONST = %q(a).#{method} + 1 * 20")
+      end
+
       it "accepts calling #{method} on a variable " do
         expect_no_offenses(<<~RUBY)
           foo = "abc"


### PR DESCRIPTION
Fixes #54 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote good commit messages.
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.