### PR TITLE
Update metadata for gemspec

### DIFF
--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |s|
   s.summary = 'Automatic performance checking tool for Ruby code.'
 
   s.metadata = {
-    'homepage_uri' => 'https://rubocop-performance.readthedocs.io/',
+    'homepage_uri' => 'https://docs.rubocop.org/projects/performance',
     'changelog_uri' => 'https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md',
     'source_code_uri' => 'https://github.com/rubocop-hq/rubocop-performance/',
-    'documentation_uri' => 'https://rubocop-performance.readthedocs.io/',
+    'documentation_uri' => 'https://docs.rubocop.org/projects/performance',
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-performance/issues'
   }
 


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop-rails/pull/59#issuecomment-495562071.

This PR updates metadata for gemspec.

The following URL is published and specified in gemspec.
https://docs.rubocop.org/projects/performance

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
