### PR TITLE
Fix a false negative for `Performance/RegexpMatch`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 147
+  Max: 149
 
 # Offense count: 14
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#54](https://github.com/rubocop-hq/rubocop-performance/issues/54): Fix `Performance/FixedSize` to accept const assign with some operation. ([@tejasbubane][])
+* [#61](https://github.com/rubocop-hq/rubocop-performance/pull/61): Fix a false negative for `Performance/RegexpMatch` when using RuboCop 0.71 or higher. ([@koic][])
 
 ## 1.3.0 (2019-05-13)
 

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -85,10 +85,13 @@ module RuboCop
 
         def_node_matcher :match_method?, <<-PATTERN
           {
-            (send _recv :match _ <int ...>)
             (send _recv :match {regexp str sym})
             (send {regexp str sym} :match _)
           }
+        PATTERN
+
+        def_node_matcher :match_with_int_arg_method?, <<-PATTERN
+          (send _recv :match _ (int ...))
         PATTERN
 
         def_node_matcher :match_operator?, <<-PATTERN
@@ -109,6 +112,7 @@ module RuboCop
         MATCH_NODE_PATTERN = <<-PATTERN
           {
             #match_method?
+            #match_with_int_arg_method?
             #match_operator?
             #match_threequals?
             #match_with_lvasgn?
@@ -143,7 +147,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            if match_method?(node)
+            if match_method?(node) || match_with_int_arg_method?(node)
               corrector.replace(node.loc.selector, 'match?')
             elsif match_operator?(node) || match_threequals?(node)
               recv, oper, arg = *node


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/pull/7081.

This PR fixes a false negartive for `Performance/RegexpMatch` when using RuboCop 0.71 or higher.

This causes CI to fail.
https://circleci.com/gh/rubocop-hq/rubocop-performance/588

This is a regression similar to #47. This PR tries to fix it using a node pattern that has been used for a long time.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
