### PR TITLE
Assert manual synchronized for CI

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -243,6 +243,20 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       .join("\n")
   end
 
+  def assert_manual_synchronized
+    # Do not print diff and yield whether exit code was zero
+    sh('git diff --quiet manual') do |outcome, _|
+      return if outcome
+
+      # Output diff before raising error
+      sh('GIT_PAGER=cat git diff manual')
+
+      warn 'The manual directory is out of sync. ' \
+        'Run `rake generate_cops_documentation` and commit the results.'
+      exit!
+    end
+  end
+
   def main
     cops   = RuboCop::Cop::Cop.registry
     config = RuboCop::ConfigLoader.load_file('config/default.yml')
@@ -253,6 +267,8 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     end
 
     print_table_of_contents(cops)
+
+    assert_manual_synchronized if ENV['CI'] == 'true'
   ensure
     RuboCop::ConfigLoader.default_configuration = nil
   end


### PR DESCRIPTION
This PR prevents the following issue.
https://github.com/rubocop-hq/rubocop-performance/pull/58#issuecomment-493995756

Therefore this PR imports the following code from RuboCop core.
https://github.com/rubocop-hq/rubocop/blob/v0.71.0/tasks/cops_documentation.rake#L234-L246

### Other Information

Built-in Environment Variable `CI` by default `true` on CircleCI.
https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
