### PR TITLE
[Fix #67] Fix an error for `Performance/RedundantMerge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#67](https://github.com/rubocop-hq/rubocop-performance/issues/67): Fix an error for `Performance/RedundantMerge` when `MaxKeyValuePairs` option is set to `null`. ([@koic][])
+
 ## 1.4.0 (2019-06-20)
 
 ### Bug fixes

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -132,7 +132,7 @@ module RuboCop
         end
 
         def max_key_value_pairs
-          Integer(cop_config['MaxKeyValuePairs'])
+          Integer(cop_config['MaxKeyValuePairs']) || 2
         end
 
         # A utility class for checking the use of values within an


### PR DESCRIPTION
Fixes #67.

This PR fixes an error for `Performance/RedundantMerge` when `MaxKeyValuePairs` option is set to `null`.

```yaml
require: rubocop-performance

Performance/RedundantMerge:
  Enabled: true
  MaxKeyValuePairs: null
```

```console
% bundle exec rubocop --only Performance/RedundantMerge -d
For /private/tmp/67: configuration from /private/tmp/67/.rubocop.yml
configuration from /Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-performance-1.4.0/config/default.yml
configuration from /Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-performance-1.4.0/config/default.yml
Default configuration from
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.72.0/config/default.yml
Inspecting 2 files
Scanning /private/tmp/67/Gemfile
.Scanning /private/tmp/67/example.rb
An error occurred while Performance/RedundantMerge cop was inspecting
/private/tmp/67/example.rb:23:2.
can't convert nil into Integer
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-performance-1.4.0/lib/rubocop/cop/performance/redundant_merge.rb:135:in
`Integer'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-performance-1.4.0/lib/rubocop/cop/performance/redundant_merge.rb:135:in
`max_key_value_pairs'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-performance-1.4.0/lib/rubocop/cop/performance/redundant_merge.rb:74:in
`non_redundant_pairs?'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-performance-1.4.0/lib/rubocop/cop/performance/redundant_merge.rb:68:in `non_redundant_merge?
```

As with `Width` option of `IndentationWidth` cop, value of default.yml
is specified as the default value.

- https://github.com/rubocop-hq/rubocop-performance/blob/v1.4.0/lib/rubocop/cop/performance/redundant_merge.rb#L131
- https://github.com/rubocop-hq/rubocop/blob/v0.72.0/config/default.yml#L794-L801

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
