### PR TITLE
Remove SafeMode from Count and Detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#74](https://github.com/rubocop-hq/rubocop-performance/pull/74): Fix an error for `Performance/RedundantMerge` when `MaxKeyValuePairs` option is set to `null`. ([@koic][])
+* [#69](https://github.com/rubocop-hq/rubocop-performance/issues/69): Remove `SafeMode` from `Performance/Count` and `Performance/Detect`. Set `SafeAutoCorrect` to `false` for these cops by default. ([@rrosenblum][])
 
 ## 1.4.1 (2019-07-29)
 
@@ -54,3 +55,4 @@
 [@bquorning]: https://github.com/bquorning
 [@dduugg]: https://github.com/dduugg
 [@tejasbubane]: https://github.com/tejasbubane
+[@rrosenblum]: https://github.com/rrosenblum

--- a/config/default.yml
+++ b/config/default.yml
@@ -44,11 +44,10 @@ Performance/Count:
   # This cop has known compatibility issues with `ActiveRecord` and other
   # frameworks. ActiveRecord's `count` ignores the block that is passed to it.
   # For more information, see the documentation in the cop itself.
-  # If you understand the known risk, you can disable `SafeMode`.
-  SafeMode: true
+  SafeAutoCorrect: false
   Enabled: true
   VersionAdded: '0.31'
-  VersionChanged: '0.39'
+  VersionChanged: '1.5'
 
 Performance/Detect:
   Description: >-
@@ -59,10 +58,10 @@ Performance/Detect:
   # frameworks. `ActiveRecord` does not implement a `detect` method and `find`
   # has its own meaning. Correcting `ActiveRecord` methods with this cop
   # should be considered unsafe.
-  SafeMode: true
+  SafeAutoCorrect: false
   Enabled: true
   VersionAdded: '0.30'
-  VersionChanged: '0.39'
+  VersionChanged: '1.5'
 
 Performance/DoubleStartEndWith:
   Description: >-

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -38,7 +38,6 @@ module RuboCop
       #
       #   Model.where(id: [1, 2, 3]).to_a.count { |m| m.method == true }
       class Count < Cop
-        include SafeMode
         include RangeHelp
 
         MSG = 'Use `count` instead of `%<selector>s...%<counter>s`.'
@@ -51,8 +50,6 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if rails_safe_mode?
-
           count_candidate?(node) do |selector_node, selector, counter|
             return unless eligible_node?(node)
 

--- a/lib/rubocop/cop/performance/detect.rb
+++ b/lib/rubocop/cop/performance/detect.rb
@@ -23,8 +23,6 @@ module RuboCop
       # own meaning. Correcting ActiveRecord methods with this cop should be
       # considered unsafe.
       class Detect < Cop
-        include SafeMode
-
         MSG = 'Use `%<prefer>s` instead of ' \
               '`%<first_method>s.%<second_method>s`.'
         REVERSE_MSG = 'Use `reverse.%<prefer>s` instead of ' \
@@ -38,8 +36,6 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if rails_safe_mode?
-
           detect_candidate?(node) do |receiver, second_method, args|
             return unless args.empty?
             return unless receiver

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -184,7 +184,7 @@ array.sort_by { |a| a[:foo] }
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.31 | 0.39
+Enabled | Yes | Yes (Unsafe) | 0.31 | 1.5
 
 This cop is used to identify usages of `count` on an `Enumerable` that
 follow calls to `select` or `reject`. Querying logic can instead be
@@ -224,17 +224,11 @@ Model.select('field AS field_one').count
 Model.select(:value).count
 ```
 
-### Configurable attributes
-
-Name | Default value | Configurable values
---- | --- | ---
-SafeMode | `true` | Boolean
-
 ## Performance/Detect
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.30 | 0.39
+Enabled | Yes | Yes (Unsafe) | 0.30 | 1.5
 
 This cop is used to identify usages of
 `select.first`, `select.last`, `find_all.first`, and `find_all.last`
@@ -258,12 +252,6 @@ considered unsafe.
 [].detect { |item| true }
 [].reverse.detect { |item| true }
 ```
-
-### Configurable attributes
-
-Name | Default value | Configurable values
---- | --- | ---
-SafeMode | `true` | Boolean
 
 ### References
 

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -271,28 +271,4 @@ RSpec.describe RuboCop::Cop::Performance::Count do
       end
     end
   end
-
-  context 'SafeMode true' do
-    subject(:cop) { described_class.new(config) }
-
-    let(:config) do
-      RuboCop::Config.new(
-        'Rails' => {
-          'Enabled' => true
-        },
-        'Performance/Count' => {
-          'SafeMode' => true
-        }
-      )
-    end
-
-    shared_examples 'selectors' do |selector|
-      it "allows using array.#{selector}...size" do
-        expect_no_offenses("[1, 2, 3].#{selector} { |e| e.even? }.size")
-      end
-    end
-
-    it_behaves_like('selectors', 'select')
-    it_behaves_like('selectors', 'reject')
-  end
 end

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -212,28 +212,4 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
     it_behaves_like 'detect_autocorrect', 'detect'
     it_behaves_like 'detect_autocorrect', 'find'
   end
-
-  context 'SafeMode true' do
-    let(:config) do
-      RuboCop::Config.new(
-        'Rails' => {
-          'Enabled' => true
-        },
-        'Style/CollectionMethods' => {
-          'PreferredMethods' => {
-            'detect' => collection_method
-          }
-        },
-        'Performance/Detect' => {
-          'SafeMode' => true
-        }
-      )
-    end
-
-    select_methods.each do |method|
-      it "doesn't register an offense when first is called on #{method}" do
-        expect_no_offenses("[1, 2, 3].#{method} { |i| i % 2 == 0 }.first")
-      end
-    end
-  end
 end


### PR DESCRIPTION
This is in response to #69. As noted in the issue, `SafeMode` has outlived its usefulness. Making use of being disabled by default or setting this as unsafe for auto-correction make more sense. 

I have left in the functionality that automatically disables these cops when the `Rails` cops are enabled. I'm not sure if that is functionality that we would like to maintain or not. These are the only 2 cops that function this way. If we remove the functionality, we can remove the `SafeMode` module from the core project.