### PR TITLE
Fix an error for `Performance/RedundantMerge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#74](https://github.com/rubocop-hq/rubocop-performance/pull/74): Fix an error for `Performance/RedundantMerge` when `MaxKeyValuePairs` option is set to `null`. ([@koic][])
+
 ## 1.4.1 (2019-07-29)
 
 ### Bug fixes

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -132,7 +132,7 @@ module RuboCop
         end
 
         def max_key_value_pairs
-          Integer(cop_config['MaxKeyValuePairs']) || 2
+          Integer(cop_config['MaxKeyValuePairs'] || 2)
         end
 
         # A utility class for checking the use of values within an

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -261,4 +261,18 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
       RUBY
     end
   end
+
+  context 'when MaxKeyValuePairs is set to nil' do
+    let(:cop_config) do
+      { 'MaxKeyValuePairs' => nil }
+    end
+
+    it 'does not raise `TypeError`' do
+      expect_offense(<<~RUBY)
+        hash = {}
+        hash.merge!(a: 1, b: 2)
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `hash[:a] = 1; hash[:b] = 2` instead of `hash.merge!(a: 1, b: 2)`.
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop-performance/pull/68#issuecomment-516072052.

#68 didn't solve an issue #67 with `Performance/RedundantMerge`.
This PR is corrected by adding a reproduction test.

Thanks @ashmaroli!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
