### PR TITLE
[Fix #70] Fix a false negative for `Performance/FlatMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#74](https://github.com/rubocop-hq/rubocop-performance/pull/74): Fix an error for `Performance/RedundantMerge` when `MaxKeyValuePairs` option is set to `null`. ([@koic][])
+* [#70](https://github.com/rubocop-hq/rubocop-performance/issues/70): This PR fixes a false negative for `Performance/FlatMap` when using symbol to proc operator argument of `map` method. ([@koic][], [@splattael][])
 
 ### Changes
 
@@ -59,3 +60,4 @@
 [@dduugg]: https://github.com/dduugg
 [@tejasbubane]: https://github.com/tejasbubane
 [@rrosenblum]: https://github.com/rrosenblum
+[@splattael]: https://github.com/splattael

--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -23,7 +23,14 @@ module RuboCop
                                   'multiple levels.'
 
         def_node_matcher :flat_map_candidate?, <<-PATTERN
-          (send (block $(send _ ${:collect :map}) ...) ${:flatten :flatten!} $...)
+          (send
+            {
+              (block $(send _ ${:collect :map}) ...)
+              $(send _ ${:collect :map} (block_pass _))
+            }
+            ${:flatten :flatten!}
+            $...
+          )
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/performance/flat_map_spec.rb
+++ b/spec/rubocop/cop/performance/flat_map_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe RuboCop::Cop::Performance::FlatMap, :config do
       expect(cop.highlights).to eq(["#{method} { |e| [e, e] }.#{flatten}(1)"])
     end
 
+    it "registers an offense when calling #{method}(&:foo).#{flatten}(1)" do
+      inspect_source("[1, 2, 3, 4].#{method}(&:foo).#{flatten}(1)")
+
+      expect(cop.messages)
+        .to eq(["Use `flat_map` instead of `#{method}...#{flatten}`."])
+      expect(cop.highlights).to eq(["#{method}(&:foo).#{flatten}(1)"])
+    end
+
+    it "registers an offense when calling #{method}(&foo).#{flatten}(1)" do
+      inspect_source("[1, 2, 3, 4].#{method}(&foo).#{flatten}(1)")
+
+      expect(cop.messages)
+        .to eq(["Use `flat_map` instead of `#{method}...#{flatten}`."])
+      expect(cop.highlights).to eq(["#{method}(&foo).#{flatten}(1)"])
+    end
+
     it "does not register an offense when calling #{method}...#{flatten} " \
       'with a number greater than 1' do
       expect_no_offenses("[1, 2, 3, 4].#{method} { |e| [e, e] }.#{flatten}(3)")
@@ -26,6 +42,20 @@ RSpec.describe RuboCop::Cop::Performance::FlatMap, :config do
       new_source = autocorrect_source(source)
 
       expect(new_source).to eq('[1, 2].flat_map { |e| [e, e] }')
+    end
+
+    it "corrects #{method}(&:foo).#{flatten} to flat_map" do
+      source = "[1, 2].#{method}(&:foo).#{flatten}(1)"
+      new_source = autocorrect_source(source)
+
+      expect(new_source).to eq('[1, 2].flat_map(&:foo)')
+    end
+
+    it "corrects #{method}(&foo).#{flatten} to flat_map" do
+      source = "[1, 2].#{method}(&:foo).#{flatten}(1)"
+      new_source = autocorrect_source(source)
+
+      expect(new_source).to eq('[1, 2].flat_map(&:foo)')
     end
   end
 


### PR DESCRIPTION
Fixes #70.

This PR fixes a false negative for `Performance/FlatMap` when using symbol to proc operator argument of `map` method.

@splattael I write your account both credit in the changelog. Thanks!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
