### PR TITLE
Add release task and release notes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
+gem 'bump', require: false
 gem 'rake'
 gem 'rspec'
 gem 'rubocop', github: 'rubocop-hq/rubocop'

--- a/relnotes/v1.0.0.md
+++ b/relnotes/v1.0.0.md
@@ -1,0 +1,6 @@
+### New features
+
+* Extract performance cops from rubocop-hq/rubocop repository. ([@composerinteralia][], [@koic][])
+
+[@composerinteralia]: https://github.com/composerinteralia
+[@koic]: https://github.com/koic

--- a/relnotes/v1.1.0.md
+++ b/relnotes/v1.1.0.md
@@ -1,0 +1,6 @@
+### Changes
+
+* [#39](https://github.com/rubocop-hq/rubocop-performance/pull/39): Remove `Performance/LstripRstrip` cop. ([@koic][])
+* [#39](https://github.com/rubocop-hq/rubocop-performance/pull/39): Remove `Performance/RedundantSortBy`, `Performance/UnneededSort` and `Performance/Sample` cops. ([@koic][])
+
+[@koic]: https://github.com/koic

--- a/relnotes/v1.2.0.md
+++ b/relnotes/v1.2.0.md
@@ -1,0 +1,5 @@
+### Bug fixes
+
+* [#47](https://github.com/rubocop-hq/rubocop-performance/pull/47): Fix a false negative for `Performance/RegexpMatch` when using RuboCop 0.68 or higher. ([@koic][])
+
+[@koic]: https://github.com/koic

--- a/relnotes/v1.3.0.md
+++ b/relnotes/v1.3.0.md
@@ -1,0 +1,5 @@
+### Bug fixes
+
+* [#48](https://github.com/rubocop-hq/rubocop-performance/issues/48): Reduce `Performance/RegexpMatch` false positive by only flagging `match` used with Regexp/String/Symbol literals. ([@dduugg][])
+
+[@dduugg]: https://github.com/dduugg

--- a/relnotes/v1.4.0.md
+++ b/relnotes/v1.4.0.md
@@ -1,0 +1,7 @@
+### Bug fixes
+
+* [#54](https://github.com/rubocop-hq/rubocop-performance/issues/54): Fix `Performance/FixedSize` to accept const assign with some operation. ([@tejasbubane][])
+* [#61](https://github.com/rubocop-hq/rubocop-performance/pull/61): Fix a false negative for `Performance/RegexpMatch` when using RuboCop 0.71 or higher. ([@koic][])
+
+[@tejasbubane]: https://github.com/tejasbubane
+[@koic]: https://github.com/koic

--- a/relnotes/v1.4.1.md
+++ b/relnotes/v1.4.1.md
@@ -1,0 +1,6 @@
+### Bug fixes
+
+* [#67](https://github.com/rubocop-hq/rubocop-performance/issues/67): Fix an error for `Performance/RedundantMerge` when `MaxKeyValuePairs` option is set to `null`. ([@koic][])
+* [#73](https://github.com/rubocop-hq/rubocop-performance/pull/73): Fix a false negative for `Performance/RegexpMatch` when `MatchData` is not detected in `if` branch of guard condition. ([@koic][])
+
+[@koic]: https://github.com/koic

--- a/relnotes/v1.5.0.md
+++ b/relnotes/v1.5.0.md
@@ -1,0 +1,10 @@
+### Bug fixes
+
+* [#74](https://github.com/rubocop-hq/rubocop-performance/pull/74): Fix an error for `Performance/RedundantMerge` when `MaxKeyValuePairs` option is set to `null`. ([@koic][])
+
+### Changes
+
+* [#69](https://github.com/rubocop-hq/rubocop-performance/issues/69): Remove `SafeMode` from `Performance/Count` and `Performance/Detect`. Set `SafeAutoCorrect` to `false` for these cops by default. ([@rrosenblum][])
+
+[@koic]: https://github.com/koic
+[@rrosenblum]: https://github.com/rrosenblum

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'bump'
+
+namespace :cut_release do
+  %w[major minor patch pre].each do |release_type|
+    desc "Cut a new #{release_type} release, create release notes " \
+         'and update documents.'
+    task release_type do
+      run(release_type)
+    end
+  end
+
+  def add_header_to_changelog(version)
+    changelog = File.read('CHANGELOG.md')
+    head, tail = changelog.split("## master (unreleased)\n\n", 2)
+
+    File.open('CHANGELOG.md', 'w') do |f|
+      f << head
+      f << "## master (unreleased)\n\n"
+      f << "## #{version} (#{Time.now.strftime('%F')})\n\n"
+      f << tail
+    end
+  end
+
+  def create_release_notes(version)
+    release_notes = new_version_changes.strip
+    contributor_links = user_links(release_notes)
+
+    File.open("relnotes/v#{version}.md", 'w') do |file|
+      file << release_notes
+      file << "\n\n"
+      file << contributor_links
+      file << "\n"
+    end
+  end
+
+  def new_version_changes
+    changelog = File.read('CHANGELOG.md')
+    _, _, new_changes, _older_changes = changelog.split(/^## .*$/, 4)
+    new_changes
+  end
+
+  def user_links(text)
+    names = text.scan(/\[@(\S+)\]\[\]/).map(&:first).uniq
+    names.map { |name| "[@#{name}]: https://github.com/#{name}" }
+         .join("\n")
+  end
+
+  def run(release_type)
+    old_version = Bump::Bump.current
+    Bump::Bump.run(release_type, commit: false, bundle: false, tag: false)
+    new_version = Bump::Bump.current
+
+    add_header_to_changelog(new_version)
+    create_release_notes(new_version)
+
+    puts "Changed version from #{old_version} to #{new_version}."
+  end
+end


### PR DESCRIPTION
This PR adds the following rake tasks.

```console
% rake -T | grep cut_release
rake cut_release:major                    # Cut a new major release,
create release notes and update documents
rake cut_release:minor                    # Cut a new minor release,
create release notes and update documents
rake cut_release:patch                    # Cut a new patch release,
create release notes and update documents
rake cut_release:pre                      # Cut a new pre release,
create release notes and update documents
```

And the release notes from v1.0.0 to v1.5.0 already released will be added.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
