### PR TITLE
Add missing bracket for Count cop documentation

### DIFF
--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -32,11 +32,11 @@ module RuboCop
       # make `count` work with a block is to call `to_a.count {...}`.
       #
       # Example:
-      #   Model.where(id: [1, 2, 3].select { |m| m.method == true }.size
+      #   `Model.where(id: [1, 2, 3]).select { |m| m.method == true }.size`
       #
       #   becomes:
       #
-      #   Model.where(id: [1, 2, 3]).to_a.count { |m| m.method == true }
+      #   `Model.where(id: [1, 2, 3]).to_a.count { |m| m.method == true }`
       class Count < Cop
         include RangeHelp
 

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -197,11 +197,11 @@ array and then run the block on the array. A simple work around to
 make `count` work with a block is to call `to_a.count {...}`.
 
 Example:
-  Model.where(id: [1, 2, 3].select { |m| m.method == true }.size
+  `Model.where(id: [1, 2, 3]).select { |m| m.method == true }.size`
 
   becomes:
 
-  Model.where(id: [1, 2, 3]).to_a.count { |m| m.method == true }
+  `Model.where(id: [1, 2, 3]).to_a.count { |m| m.method == true }`
 
 ### Examples
 


### PR DESCRIPTION
There's a bracket missing in the entry for the `Performance/Count` in the manual.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
