### PR TITLE
[Fix #86] Fix an incorrect autocorrect for `Performance/RedundantMerge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#86](https://github.com/rubocop-hq/rubocop-performance/issues/86): Fix an incorrect autocorrect for `Performance/RedundantMerge` when using an empty hash argument. ([@koic][])
+
 ## 1.5.1 (2019-11-14)
 
 ### Bug fixes

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -65,7 +65,8 @@ module RuboCop
         end
 
         def non_redundant_merge?(node, receiver, pairs)
-          non_redundant_pairs?(receiver, pairs) ||
+          pairs.empty? ||
+            non_redundant_pairs?(receiver, pairs) ||
             kwsplat_used?(pairs) ||
             non_redundant_value_used?(receiver, node)
         end

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -235,6 +235,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
     end
   end
 
+  it 'does not register an offense when using an empty hash argument' do
+    expect_no_offenses(<<~RUBY)
+      foo.merge!({})
+    RUBY
+  end
+
   it "doesn't register an error when return value is used" do
     expect_no_offenses(<<~RUBY)
       variable = hash.merge!(a: 1)


### PR DESCRIPTION
Fixes #86.

This PR fixes the following incorrect autocorrect for `Performance/RedundantMerge` when using an empty hash argument.

```console
% cat example.rb
def something
  hash.merge!({}) if blah?
  hash
end

% rubocop --only Performance/RedundantMerge -a
Inspecting 1 file
E

Offenses:

example.rb:2:3: C: [Corrected] Performance/RedundantMerge: Use  instead
of hash.merge!({}).
  hash.merge!({}) if blah?
  ^^^^^^^^^^^^^^^
example.rb:5:1: E: Lint/Syntax: unexpected token $end
(Using Ruby 2.6 parser; configure using TargetRubyVersion parameter,
under AllCops)

1 file inspected, 2 offenses detected, 1 offense corrected

% cat example.rb
def something
   if blah?
  hash
end
```

There is no good case code to replace an empty hash argument, so this PR changes it to not offense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
