### PR TITLE
CI against Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ workflows:
           name: Ruby 2.6
           image: circleci/ruby:2.6
       - rake_default:
+          name: Ruby 2.7
+          image: circleci/ruby:2.7
+      - rake_default:
           name: Ruby HEAD
           image: rubocophq/circleci-ruby-snapshot:latest # Nightly snapshot build
       - rake_default:


### PR DESCRIPTION
Ruby 2.7.0 has been released and this Ruby version is available on `circleci/ruby:2.7` image.

- https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
- https://hub.docker.com/r/circleci/ruby/tags/

```console
% docker pull circleci/ruby:2.7
2.7: Pulling from circleci/ruby

(snip)

Status: Downloaded newer image for circleci/ruby:2.7
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
