### PR TITLE
[Fix #77] Add new `Performance/BindCall` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#77](https://github.com/rubocop-hq/rubocop-performance/issues/77): Add new `Performance/BindCall` cop. ([@koic][])
+
 ## 1.5.2 (2019-12-25)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,10 @@
 # This is the default configuration file.
 
+Performance/BindCall:
+  Description: 'Use `bind_call(obj, args, ...)` instead of `bind(obj).call(args, ...)`.'
+  Enabled: true
+  VersionAdded: '1.6'
+
 Performance/Caller:
   Description: >-
              Use `caller(n..n)` instead of `caller`.

--- a/lib/rubocop/cop/performance/bind_call.rb
+++ b/lib/rubocop/cop/performance/bind_call.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Performance
+      # In Ruby 2.7, `UnboundMethod#bind_call` has been added.
+      #
+      # This cop identifies places where `bind(obj).call(args, ...)`
+      # can be replaced by `bind_call(obj, args, ...)`.
+      #
+      # The `bind_call(obj, args, ...)` method is faster than
+      # `bind(obj).call(args, ...)`.
+      #
+      # @example
+      #   # bad
+      #   umethod.bind(obj).call(foo, bar)
+      #   umethod.bind(obj).(foo, bar)
+      #
+      #   # good
+      #   umethod.bind_call(obj, foo, bar)
+      #
+      class BindCall < Cop
+        include RangeHelp
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.7
+
+        MSG = 'Use `bind_call(%<bind_arg>s%<comma>s%<call_args>s)` ' \
+              'instead of `bind(%<bind_arg>s).call(%<call_args>s)`.'
+
+        def_node_matcher :bind_with_call_method?, <<~PATTERN
+          (send
+            $(send
+              (send nil? _) :bind
+              $(...)) :call
+            $...)
+        PATTERN
+
+        def on_send(node)
+          bind_with_call_method?(node) do |receiver, bind_arg, call_args_node|
+            range = correction_range(receiver, node)
+
+            call_args = build_call_args(call_args_node)
+
+            message = message(bind_arg.source, call_args)
+
+            add_offense(node, location: range, message: message)
+          end
+        end
+
+        def autocorrect(node)
+          receiver, bind_arg, call_args_node = bind_with_call_method?(node)
+
+          range = correction_range(receiver, node)
+
+          call_args = build_call_args(call_args_node)
+          call_args = ", #{call_args}" unless call_args.empty?
+
+          replacement_method = "bind_call(#{bind_arg.source}#{call_args})"
+
+          lambda do |corrector|
+            corrector.replace(range, replacement_method)
+          end
+        end
+
+        private
+
+        def message(bind_arg, call_args)
+          comma = call_args.empty? ? '' : ', '
+
+          format(MSG, bind_arg: bind_arg, comma: comma, call_args: call_args)
+        end
+
+        def correction_range(receiver, node)
+          location_of_bind = receiver.loc.selector.begin_pos
+          location_of_call = node.loc.end.end_pos
+
+          range_between(location_of_bind, location_of_call)
+        end
+
+        def build_call_args(call_args_node)
+          call_args_node.map(&:source).join(', ')
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/performance_cops.rb
+++ b/lib/rubocop/cop/performance_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'performance/bind_call'
 require_relative 'performance/caller'
 require_relative 'performance/case_when_splat'
 require_relative 'performance/casecmp'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -1,6 +1,7 @@
 <!-- START_COP_LIST -->
 #### Department [Performance](cops_performance.md)
 
+* [Performance/BindCall](cops_performance.md#performancebindcall)
 * [Performance/Caller](cops_performance.md#performancecaller)
 * [Performance/CaseWhenSplat](cops_performance.md#performancecasewhensplat)
 * [Performance/Casecmp](cops_performance.md#performancecasecmp)

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -1,5 +1,30 @@
 # Performance
 
+## Performance/BindCall
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.6 | -
+
+In Ruby 2.7, `UnboundMethod#bind_call` has been added.
+
+This cop identifies places where `bind(obj).call(args, ...)`
+can be replaced by `bind_call(obj, args, ...)`.
+
+The `bind_call(obj, args, ...)` method is faster than
+`bind(obj).call(args, ...)`.
+
+### Examples
+
+```ruby
+# bad
+umethod.bind(obj).call(foo, bar)
+umethod.bind(obj).(foo, bar)
+
+# good
+umethod.bind_call(obj, foo, bar)
+```
+
 ## Performance/Caller
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/rubocop/cop/performance/bind_call_spec.rb
+++ b/spec/rubocop/cop/performance/bind_call_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Performance::BindCall, :config do
+  subject(:cop) { described_class.new(config) }
+
+  context 'TargetRubyVersion <= 2.6', :ruby26 do
+    it 'does not register an offense when using `bind(obj).call(args, ...)`' do
+      expect_no_offenses(<<~RUBY)
+        umethod.bind(obj).call(foo, bar)
+      RUBY
+    end
+  end
+
+  context 'TargetRubyVersion >= 2.7', :ruby27 do
+    it 'registers an offense when using `bind(obj).call(args, ...)`' do
+      expect_offense(<<~RUBY)
+        umethod.bind(obj).call(foo, bar)
+                ^^^^^^^^^^^^^^^^^^^^^^^^ Use `bind_call(obj, foo, bar)` instead of `bind(obj).call(foo, bar)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        umethod.bind_call(obj, foo, bar)
+      RUBY
+    end
+
+    it 'registers an offense when using `bind(obj).()`' do
+      expect_offense(<<~RUBY)
+        umethod.bind(obj).()
+                ^^^^^^^^^^^^ Use `bind_call(obj)` instead of `bind(obj).call()`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        umethod.bind_call(obj)
+      RUBY
+    end
+
+    it 'registers an offense when the argument of `bind` method is a string' do
+      expect_offense(<<~RUBY)
+        umethod.bind('obj').call(foo, bar)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `bind_call('obj', foo, bar)` instead of `bind('obj').call(foo, bar)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        umethod.bind_call('obj', foo, bar)
+      RUBY
+    end
+
+    it 'registers an offense when a argument of `call` method is a string' do
+      expect_offense(<<~RUBY)
+        umethod.bind(obj).call('foo', bar)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `bind_call(obj, 'foo', bar)` instead of `bind(obj).call('foo', bar)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        umethod.bind_call(obj, 'foo', bar)
+      RUBY
+    end
+
+    it 'does not register an offense when using `bind_call(obj, args, ...)`' do
+      expect_no_offenses(<<~RUBY)
+        umethod.bind_call(obj, foo, bar)
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Fixes #77.

This PR adds new `Performance/BindCall` cop.

In Ruby 2.7, `UnboundMethod#bind_call` has been added.

- https://bugs.ruby-lang.org/issues/15955
- https://github.com/ruby/ruby/commit/83c6a1e

The `bind_call(obj, args, ...)` method is faster than `bind(obj).call(args, ...)`.

```console
% ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin17]

% gem i benchmark-ips
(snip)

% cat bench.rb
require 'benchmark/ips'

Benchmark.ips do |x|
  umethod = String.instance_method(:start_with?)

  x.report('bind.call') { umethod.bind('hello, world').call('hello') }
  x.report('bind_call') { umethod.bind_call('hello, world', 'hello') }

  x.compare!
end

% ruby bench.rb
Warming up --------------------------------------
           bind.call   122.167k i/100ms
           bind_call   189.749k i/100ms
Calculating -------------------------------------
           bind.call      1.795M (± 1.7%) i/s -      9.040M in   5.039135s
           bind_call      3.756M (± 2.2%) i/s -     18.785M in   5.004573s

Comparison:
           bind_call:  3755510.3 i/s
           bind.call:  1794560.4 i/s - 2.09x  slower
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
