### PR TITLE
Use `git ls-files -z` instead of splitting with newline

### DIFF
--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   DESCRIPTION
 
   s.email = 'rubocop@googlegroups.com'
-  s.files = `git ls-files config lib LICENSE.txt README.md`.split($RS)
+  s.files = `git ls-files -z config lib LICENSE.txt README.md`.split("\x0")
   s.extra_rdoc_files = ['LICENSE.txt', 'README.md']
   s.homepage = 'https://github.com/rubocop-hq/rubocop-performance'
   s.licenses = ['MIT']


### PR DESCRIPTION
It suppresses the following warning.


```bash
$ bundle exec rake 
/home/pocke/ghq/github.com/rubocop-hq/rubocop-performance/rubocop-performance.gemspec:18: warning: global variable `$RS' not initialized

(snip)
```


The gemspec will use the null character separated string for file list instead of a newline.
I think it is more appropriate because a file path can contain a newline.
And `bundle gem`'s boilerplate also uses `-z` option.