### PR TITLE
Add `require: false` to example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ gem install rubocop-performance
 or if you use bundler put this in your `Gemfile`
 
 ```ruby
-gem 'rubocop-performance'
+gem 'rubocop-performance', require: false
 ```
 
 ## Usage


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop-rspec/pull/859.

This PR adds `require: false` to example code in README.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
