### PR TITLE
[Fix #101] Mark unsafe for `Performance/Casecmp` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * [#103](https://github.com/rubocop-hq/rubocop-performance/pull/103): **(BREAKING)** Drop support for Ruby 2.3. ([@koic][])
+* [#101](https://github.com/rubocop-hq/rubocop-performance/issues/101): Mark unsafe for `Performance/Casecmp` cop. ([@koic][])
 
 ## 1.5.2 (2019-12-25)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -26,6 +26,7 @@ Performance/Casecmp:
              Use `casecmp` rather than `downcase ==`, `upcase ==`, `== downcase`, or `== upcase`..
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringcasecmp-vs-stringdowncase---code'
   Enabled: true
+  Safe: false
   VersionAdded: '0.36'
 
 Performance/ChainArrayAllocation:

--- a/lib/rubocop/cop/performance/casecmp.rb
+++ b/lib/rubocop/cop/performance/casecmp.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Performance
       # This cop identifies places where a case-insensitive string comparison
       # can better be implemented using `casecmp`.
+      # This cop is unsafe because `String#casecmp` and `String#casecmp?` behave
+      # differently when using Non-ASCII characters.
       #
       # @example
       #   # bad

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -120,10 +120,12 @@ AutoCorrect | `false` | Boolean
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.36 | -
+Enabled | No | Yes  | 0.36 | -
 
 This cop identifies places where a case-insensitive string comparison
 can better be implemented using `casecmp`.
+This cop is unsafe because `String#casecmp` and `String#casecmp?` behave
+differently when using Non-ASCII characters.
 
 ### Examples
 


### PR DESCRIPTION
Fixes #101.

`String#casecmp` and `String#casecmp?` behave differently when using Non-ASCII characters.

```console
'äöü'.casecmp('ÄÖÜ').zero? #=> false
'äöü'.casecmp?('ÄÖÜ')      #=> true
```

I thought about using a String literal encoding to prevent false positives. But, it is difficult to
static analyze the encoding of strings passed from outside.
As a result, this PR marks unsafe for `Performance/Casecmp` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
