### PR TITLE
Fixes multi-line ReverseEach autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Bug fixes
+* [#108](https://github.com/rubocop-hq/rubocop-performance/pull/108): Fix an incorrect autocorrect for `Performance/ReverseEach` when there is a newline between reverse and each. ([@joe-sharp][], [@dischorde][], [@siegfault][])
+
 ### New features
 
 * [#77](https://github.com/rubocop-hq/rubocop-performance/issues/77): Add new `Performance/BindCall` cop. ([@koic][])
@@ -86,3 +89,6 @@
 [@rrosenblum]: https://github.com/rrosenblum
 [@splattael]: https://github.com/splattael
 [@eugeneius]: https://github.com/eugeneius
+[@joe-sharp]: https://github.com/joe-sharp
+[@dischorde]: https://github.com/dischorde
+[@siegfault]: https://github.com/siegfault

--- a/lib/rubocop/cop/performance/reverse_each.rb
+++ b/lib/rubocop/cop/performance/reverse_each.rb
@@ -34,7 +34,8 @@ module RuboCop
         end
 
         def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.dot, UNDERSCORE) }
+          range = range_between(node.loc.dot.begin_pos, node.loc.selector.begin_pos)
+          ->(corrector) { corrector.replace(range, UNDERSCORE) }
         end
       end
     end

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
     RUBY
   end
 
+  it 'registers an offense for a multi-line reverse.each' do
+    expect_offense(<<~RUBY)
+      def arr
+        [1, 2, 3]
+      end
+
+      arr.
+        reverse.
+        ^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
+        each { |e| puts e }
+    RUBY
+  end
+
   it 'does not register an offense when reverse is used without each' do
     expect_no_offenses('[1, 2, 3].reverse')
   end
@@ -71,6 +84,27 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
         end
 
         arr.reverse_each { |e| puts e }
+      RUBY
+    end
+
+    it 'corrects a multi-line reverse_each' do
+      new_source = autocorrect_source(<<~RUBY)
+        def arr
+          [1, 2]
+        end
+
+        arr.
+          reverse.
+          each { |e| puts e }
+      RUBY
+
+      expect(new_source).to eq(<<~RUBY)
+        def arr
+          [1, 2]
+        end
+
+        arr.
+          reverse_each { |e| puts e }
       RUBY
     end
   end


### PR DESCRIPTION
When reverse and each are on separate lines, we end up autocorrecting
```ruby
foo.reverse.
  each { ... }
```
to
```ruby
foo.reverse_
  each { ... }
```
. With this change, we will instead update to
```ruby
foo.reverse_each { ... }
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/

cc: @joe-sharp @dischorde