### PR TITLE
[Fix #55] Fix an incorrect autocorrect for `Performance/RegexpMatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * [#105](https://github.com/rubocop-hq/rubocop-performance/pull/105): Add new `Performance/DeletePrefix` and `Performance/DeleteSuffix` cops. ([@koic][])
 
 ### Bug fixes
+
+* [#55](https://github.com/rubocop-hq/rubocop-performance/issues/55): Fix an incorrect autocorrect for `Performance/RegexpMatch` when using `str.=~(/regexp/)`. ([@koic][])
 * [#108](https://github.com/rubocop-hq/rubocop-performance/pull/108): Fix an incorrect autocorrect for `Performance/ReverseEach` when there is a newline between reverse and each. ([@joe-sharp][], [@dischorde][], [@siegfault][])
 
 ### Changes

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -252,6 +252,13 @@ module RuboCop
         def correct_operator(corrector, recv, arg, oper = nil)
           op_range = correction_range(recv, arg)
 
+          replace_with_match_predicate_method(corrector, recv, arg, op_range)
+
+          corrector.insert_after(arg.loc.expression, ')') unless op_range.source.end_with?('(')
+          corrector.insert_before(recv.loc.expression, '!') if oper == :!~
+        end
+
+        def replace_with_match_predicate_method(corrector, recv, arg, op_range)
           if TYPES_IMPLEMENTING_MATCH.include?(recv.type)
             corrector.replace(op_range, '.match?(')
           elsif TYPES_IMPLEMENTING_MATCH.include?(arg.type)
@@ -260,9 +267,6 @@ module RuboCop
           else
             corrector.replace(op_range, '&.match?(')
           end
-
-          corrector.insert_after(arg.loc.expression, ')')
-          corrector.insert_before(recv.loc.expression, '!') if oper == :!~
         end
 
         def swap_receiver_and_arg(corrector, recv, arg)

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -342,6 +342,8 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
   it_behaves_like('all legacy match methods', 'matching by =~`',
                   're =~ "foo"', '"foo".match?(re)')
   it_behaves_like('all legacy match methods', 'matching by =~`',
+                  're.=~("foo")', '"foo".match?(re)')
+  it_behaves_like('all legacy match methods', 'matching by =~`',
                   ':foo =~ re', ':foo.match?(re)')
   it_behaves_like('all legacy match methods', 'matching by =~`',
                   're =~ :foo', ':foo.match?(re)')


### PR DESCRIPTION
Fixes #55.

This PR fixes an incorrect autocorrect for `Performance/RegexpMatch` cop when using `str.=~(/regexp/)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
