### PR TITLE
Add required Ruby version to generated cops manual

### DIFF
--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -2,6 +2,10 @@
 
 ## Performance/BindCall
 
+!!! Note
+
+    Required Ruby version: 2.7
+
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 1.6 | -
@@ -253,6 +257,10 @@ Model.select(:value).count
 
 ## Performance/DeletePrefix
 
+!!! Note
+
+    Required Ruby version: 2.5
+
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 1.6 | -
@@ -280,6 +288,10 @@ str.delete_prefix!('prefix')
 ```
 
 ## Performance/DeleteSuffix
+
+!!! Note
+
+    Required Ruby version: 2.5
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -17,6 +17,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def cops_body(config, cop, description, examples_objects, pars)
     content = h2(cop.cop_name)
+    content << required_ruby_version(cop)
     content << properties(config, cop)
     content << "#{description}\n"
     content << examples(examples_objects) if examples_objects.count.positive?
@@ -30,6 +31,17 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       content << h4(example.name) unless example.name == ''
       content << code_example(example)
     end
+  end
+
+  def required_ruby_version(cop)
+    return '' unless cop.respond_to?(:required_minimum_ruby_version)
+
+    <<~NOTE
+      !!! Note
+
+          Required Ruby version: #{cop.required_minimum_ruby_version}
+
+    NOTE
   end
 
   # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
Follow up to https://github.com/rubocop-hq/rubocop/pull/7947.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
