### PR TITLE
[Fix #111] Fix an error for `Performance/DeletePrefix` and `Performance/DeleteSuffix` cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#111](https://github.com/rubocop-hq/rubocop-performance/issues/111): Fix an error for `Performance/DeletePrefix` and `Performance/DeleteSuffix` cops when using autocorrection with RuboCop 0.81 or lower. ([@koic][])
+
 ## 1.6.0 (2020-05-22)
 
 ### New features

--- a/lib/rubocop/cop/performance/delete_prefix.rb
+++ b/lib/rubocop/cop/performance/delete_prefix.rb
@@ -62,7 +62,9 @@ module RuboCop
 
               new_code = "#{receiver.source}.#{good_method}(#{string_literal})"
 
-              corrector.replace(node, new_code)
+              # TODO: `source_range` is no longer required when RuboCop 0.81 or lower support will be dropped.
+              # https://github.com/rubocop-hq/rubocop/commit/82eb350d2cba16
+              corrector.replace(node.source_range, new_code)
             end
           end
         end

--- a/lib/rubocop/cop/performance/delete_suffix.rb
+++ b/lib/rubocop/cop/performance/delete_suffix.rb
@@ -62,7 +62,9 @@ module RuboCop
 
               new_code = "#{receiver.source}.#{good_method}(#{string_literal})"
 
-              corrector.replace(node, new_code)
+              # TODO: `source_range` is no longer required when RuboCop 0.81 or lower support will be dropped.
+              # https://github.com/rubocop-hq/rubocop/commit/82eb350d2cba16
+              corrector.replace(node.source_range, new_code)
             end
           end
         end


### PR DESCRIPTION
Fixes #111.

This PR fixes an error for `Performance/DeletePrefix` and `Performance/DeleteSuffix` cops when using autocorrection with RuboCop 0.81 or lower.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
