### PR TITLE
Specify testing context of Ruby 2.7 for `Performance/BindCall`

### DIFF
--- a/spec/rubocop/cop/performance/bind_call_spec.rb
+++ b/spec/rubocop/cop/performance/bind_call_spec.rb
@@ -3,6 +3,10 @@
 RSpec.describe RuboCop::Cop::Performance::BindCall, :config do
   subject(:cop) { described_class.new(config) }
 
+  # TODO: The following is no longer required when RuboCop 0.78 or lower support will be dropped.
+  # https://github.com/rubocop-hq/rubocop/pull/7605
+  let(:ruby_version) { 2.7 }
+
   context 'TargetRubyVersion <= 2.6', :ruby26 do
     it 'does not register an offense when using `bind(obj).call(args, ...)`' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR prepares for #112 and makes the `rake spec` successful with RuboCop 0.71, which is supported by RuboCop Performance 1.6.

This is a workaround until the CI is ready for RuboCop Performance 1.7.
RuboCop Performance 1.7 will drop some older RuboCop support versions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
