### PR TITLE
[Fix #115] DeletePrefix and DeleteSuffix cops detects sub/sub! String methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#115](https://github.com/rubocop-hq/rubocop-performance/issues/115): Support `String#sub` and `String#sub!` methods for `Performance/DeletePrefix` and `Performance/DeleteSuffix` cops. ([@fatkodima][])
+
 ### Bug fixes
 
 * [#111](https://github.com/rubocop-hq/rubocop-performance/issues/111): Fix an error for `Performance/DeletePrefix` and `Performance/DeleteSuffix` cops when using autocorrection with RuboCop 0.81 or lower. ([@koic][])
@@ -101,3 +105,4 @@
 [@joe-sharp]: https://github.com/joe-sharp
 [@dischorde]: https://github.com/dischorde
 [@siegfault]: https://github.com/siegfault
+[@fatkodima]: https://github.com/fatkodima

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -267,7 +267,7 @@ Enabled | Yes | Yes  | 1.6 | -
 
 In Ruby 2.5, `String#delete_prefix` has been added.
 
-This cop identifies places where `gsub(/\Aprefix/, '')`
+This cop identifies places where `gsub(/\Aprefix/, '')` and `sub(/\Aprefix/, '')`
 can be replaced by `delete_prefix('prefix')`.
 
 The `delete_prefix('prefix')` method is faster than
@@ -281,6 +281,11 @@ str.gsub(/\Aprefix/, '')
 str.gsub!(/\Aprefix/, '')
 str.gsub(/^prefix/, '')
 str.gsub!(/^prefix/, '')
+
+str.sub(/\Aprefix/, '')
+str.sub!(/\Aprefix/, '')
+str.sub(/^prefix/, '')
+str.sub!(/^prefix/, '')
 
 # good
 str.delete_prefix('prefix')
@@ -299,7 +304,7 @@ Enabled | Yes | Yes  | 1.6 | -
 
 In Ruby 2.5, `String#delete_suffix` has been added.
 
-This cop identifies places where `gsub(/suffix\z/, '')`
+This cop identifies places where `gsub(/suffix\z/, '')` and `sub(/suffix\z/, '')`
 can be replaced by `delete_suffix('suffix')`.
 
 The `delete_suffix('suffix')` method is faster than
@@ -313,6 +318,11 @@ str.gsub(/suffix\z/, '')
 str.gsub!(/suffix\z/, '')
 str.gsub(/suffix$/, '')
 str.gsub!(/suffix$/, '')
+
+str.sub(/suffix\z/, '')
+str.sub!(/suffix\z/, '')
+str.sub(/suffix$/, '')
+str.sub!(/suffix$/, '')
 
 # good
 str.delete_suffix('suffix')

--- a/spec/rubocop/cop/performance/delete_prefix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_prefix_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
         str.gsub!(/\\Aprefix/, '')
       RUBY
     end
+
+    it "does not register an offense when using `sub(/\Aprefix/, '')`" do
+      expect_no_offenses(<<~RUBY)
+        str.sub(/\\Aprefix/, '')
+      RUBY
+    end
+
+    it "does not register an offense when using `sub!(/\Aprefix/, '')`" do
+      expect_no_offenses(<<~RUBY)
+        str.sub!(/\\Aprefix/, '')
+      RUBY
+    end
   end
 
   context 'TargetRubyVersion >= 2.5', :ruby25 do
@@ -34,6 +46,28 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
         expect_offense(<<~RUBY)
           str.gsub!(/\\Aprefix/, '')
               ^^^^^ Use `delete_prefix!` instead of `gsub!`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          str.delete_prefix!('prefix')
+        RUBY
+      end
+
+      it "registers an offense and corrects when `sub(/\Aprefix/, '')`" do
+        expect_offense(<<~RUBY)
+          str.sub(/\\Aprefix/, '')
+              ^^^ Use `delete_prefix` instead of `sub`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          str.delete_prefix('prefix')
+        RUBY
+      end
+
+      it "registers an offense and corrects when `sub!(/\Aprefix/, '')`" do
+        expect_offense(<<~RUBY)
+          str.sub!(/\\Aprefix/, '')
+              ^^^^ Use `delete_prefix!` instead of `sub!`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -64,6 +98,28 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
           str.delete_prefix!('prefix')
         RUBY
       end
+
+      it 'registers an offense and corrects when using `sub`' do
+        expect_offense(<<~RUBY)
+          str.sub(/^prefix/, '')
+              ^^^ Use `delete_prefix` instead of `sub`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          str.delete_prefix('prefix')
+        RUBY
+      end
+
+      it 'registers an offense and corrects when using `sub!`' do
+        expect_offense(<<~RUBY)
+          str.sub!(/^prefix/, '')
+              ^^^^ Use `delete_prefix!` instead of `sub!`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          str.delete_prefix!('prefix')
+        RUBY
+      end
     end
 
     context 'when using non-starting pattern' do
@@ -76,6 +132,18 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
       it 'does not register an offense when using `gsub!`' do
         expect_no_offenses(<<~RUBY)
           str.gsub!(/pattern/, '')
+        RUBY
+      end
+
+      it 'does not register an offense when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/pattern/, '')
+        RUBY
+      end
+
+      it 'does not register an offense when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/pattern/, '')
         RUBY
       end
     end
@@ -92,6 +160,18 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
           str.gsub!(/\\Aprefix\\z/, '')
         RUBY
       end
+
+      it 'does not register an offense and corrects when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/\\Aprefix\\z/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/\\Aprefix\\z/, '')
+        RUBY
+      end
     end
 
     context 'when using a non-blank string as replacement string' do
@@ -104,6 +184,18 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
       it 'does not register an offense and corrects when using `gsub!`' do
         expect_no_offenses(<<~RUBY)
           str.gsub!(/\\Aprefix/, 'foo')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/\\Aprefix/, 'foo')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/\\Aprefix/, 'foo')
         RUBY
       end
     end

--- a/spec/rubocop/cop/performance/delete_suffix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_suffix_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
         str.gsub!(/suffix\\z/, '')
       RUBY
     end
+
+    it "does not register an offense when using `sub(/suffix\z/, '')`" do
+      expect_no_offenses(<<~RUBY)
+        str.sub(/suffix\\z/, '')
+      RUBY
+    end
+
+    it "does not register an offense when using `sub!(/suffix\z/, '')`" do
+      expect_no_offenses(<<~RUBY)
+        str.sub!(/suffix\\z/, '')
+      RUBY
+    end
   end
 
   context 'TargetRubyVersion >= 2.5', :ruby25 do
@@ -34,6 +46,28 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
         expect_offense(<<~RUBY)
           str.gsub!(/suffix\\z/, '')
               ^^^^^ Use `delete_suffix!` instead of `gsub!`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          str.delete_suffix!('suffix')
+        RUBY
+      end
+
+      it "registers an offense and corrects when `sub(/suffix\z/, '')`" do
+        expect_offense(<<~RUBY)
+          str.sub(/suffix\\z/, '')
+              ^^^ Use `delete_suffix` instead of `sub`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          str.delete_suffix('suffix')
+        RUBY
+      end
+
+      it "registers an offense and corrects when `sub!(/suffix\z/, '')`" do
+        expect_offense(<<~RUBY)
+          str.sub!(/suffix\\z/, '')
+              ^^^^ Use `delete_suffix!` instead of `sub!`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -64,6 +98,28 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
           str.delete_suffix!('suffix')
         RUBY
       end
+
+      it 'registers an offense and corrects when using `sub`' do
+        expect_offense(<<~RUBY)
+          str.sub(/suffix$/, '')
+              ^^^ Use `delete_suffix` instead of `sub`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          str.delete_suffix('suffix')
+        RUBY
+      end
+
+      it 'registers an offense and corrects when using `sub!`' do
+        expect_offense(<<~RUBY)
+          str.sub!(/suffix$/, '')
+              ^^^^ Use `delete_suffix!` instead of `sub!`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          str.delete_suffix!('suffix')
+        RUBY
+      end
     end
 
     context 'when using non-ending pattern' do
@@ -76,6 +132,18 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
       it 'does not register an offense when using `gsub!`' do
         expect_no_offenses(<<~RUBY)
           str.gsub!(/pattern/, '')
+        RUBY
+      end
+
+      it 'does not register an offense when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/pattern/, '')
+        RUBY
+      end
+
+      it 'does not register an offense when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/pattern/, '')
         RUBY
       end
     end
@@ -92,6 +160,18 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
           str.gsub!(/\\Asuffix\\z/, '')
         RUBY
       end
+
+      it 'does not register an offense and corrects when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/\\Asuffix\\z/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/\\Asuffix\\z/, '')
+        RUBY
+      end
     end
 
     context 'when using a non-blank string as replacement string' do
@@ -104,6 +184,18 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
       it 'does not register an offense and corrects when using `gsub!`' do
         expect_no_offenses(<<~RUBY)
           str.gsub!(/suffix\\z/, 'foo')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/suffix\\z/, 'foo')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/suffix\\z/, 'foo')
         RUBY
       end
     end


### PR DESCRIPTION
```ruby
# bad
str.sub(/suffix\z/, '')
str.sub!(/suffix\z/, '')
str.sub(/suffix$/, '')
str.sub!(/suffix$/, '')

# good
str.delete_suffix('suffix')
str.delete_suffix!('suffix')

# bad
str.sub(/\Aprefix/, '')
str.sub!(/\Aprefix/, '')
str.sub(/^prefix/, '')
str.sub!(/^prefix/, '')

# good
str.delete_prefix('prefix')
str.delete_prefix!('prefix')
```

Closes #115 