### PR TITLE
[Fix #118] Fix a false positive for `DeletePrefix` and `DeletePrefix` cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#111](https://github.com/rubocop-hq/rubocop-performance/issues/111): Fix an error for `Performance/DeletePrefix` and `Performance/DeleteSuffix` cops when using autocorrection with RuboCop 0.81 or lower. ([@koic][])
+* [#118](https://github.com/rubocop-hq/rubocop-performance/issues/118): Fix a false positive for `Performance/DeletePrefix`, `Performance/DeleteSuffix`, `Performance/StartWith`, and `Performance/EndWith` cops when receiver is multiline string. ([@koic][])
 
 ## 1.6.0 (2020-05-22)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -58,11 +58,13 @@ Performance/Count:
 Performance/DeletePrefix:
   Description: 'Use `delete_prefix` instead of `gsub`.'
   Enabled: true
+  SafeMultiline: true
   VersionAdded: '1.6'
 
 Performance/DeleteSuffix:
   Description: 'Use `delete_suffix` instead of `gsub`.'
   Enabled: true
+  SafeMultiline: true
   VersionAdded: '1.6'
 
 Performance/Detect:
@@ -99,8 +101,9 @@ Performance/EndWith:
   SafeAutoCorrect: false
   AutoCorrect: false
   Enabled: true
+  SafeMultiline: true
   VersionAdded: '0.36'
-  VersionChanged: '0.44'
+  VersionChanged: '1.6'
 
 Performance/FixedSize:
   Description: 'Do not compute the size of statically sized objects except in constants.'
@@ -193,8 +196,9 @@ Performance/StartWith:
   SafeAutoCorrect: false
   AutoCorrect: false
   Enabled: true
+  SafeMultiline: true
   VersionAdded: '0.36'
-  VersionChanged: '0.44'
+  VersionChanged: '1.6'
 
 Performance/StringReplacement:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -327,8 +327,11 @@ In Ruby 2.5, `String#delete_prefix` has been added.
 This cop identifies places where `gsub(/\Aprefix/, '')` and `sub(/\Aprefix/, '')`
 can be replaced by `delete_prefix('prefix')`.
 
-The `delete_prefix('prefix')` method is faster than
-`gsub(/\Aprefix/, '')`.
+This cop has `SafeMultiline` configuration option that `true` by default because
+`^prefix` is unsafe as it will behave incompatible with `delete_prefix`
+for receiver is multiline string.
+
+The `delete_prefix('prefix')` method is faster than `gsub(/\Aprefix/, '')`.
 
 === Examples
 
@@ -337,18 +340,46 @@ The `delete_prefix('prefix')` method is faster than
 # bad
 str.gsub(/\Aprefix/, '')
 str.gsub!(/\Aprefix/, '')
-str.gsub(/^prefix/, '')
-str.gsub!(/^prefix/, '')
 
 str.sub(/\Aprefix/, '')
 str.sub!(/\Aprefix/, '')
-str.sub(/^prefix/, '')
-str.sub!(/^prefix/, '')
 
 # good
 str.delete_prefix('prefix')
 str.delete_prefix!('prefix')
 ----
+
+==== SafeMultiline: true (default)
+
+[source,ruby]
+----
+# good
+str.gsub(/^prefix/, '')
+str.gsub!(/^prefix/, '')
+str.sub(/^prefix/, '')
+str.sub!(/^prefix/, '')
+----
+
+==== SafeMultiline: false
+
+[source,ruby]
+----
+# bad
+str.gsub(/^prefix/, '')
+str.gsub!(/^prefix/, '')
+str.sub(/^prefix/, '')
+str.sub!(/^prefix/, '')
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| SafeMultiline
+| `true`
+| Boolean
+|===
 
 == Performance/DeleteSuffix
 
@@ -369,8 +400,11 @@ In Ruby 2.5, `String#delete_suffix` has been added.
 This cop identifies places where `gsub(/suffix\z/, '')` and `sub(/suffix\z/, '')`
 can be replaced by `delete_suffix('suffix')`.
 
-The `delete_suffix('suffix')` method is faster than
-`gsub(/suffix\z/, '')`.
+This cop has `SafeMultiline` configuration option that `true` by default because
+`suffix$` is unsafe as it will behave incompatible with `delete_suffix?`
+for receiver is multiline string.
+
+The `delete_suffix('suffix')` method is faster than `gsub(/suffix\z/, '')`.
 
 === Examples
 
@@ -379,18 +413,46 @@ The `delete_suffix('suffix')` method is faster than
 # bad
 str.gsub(/suffix\z/, '')
 str.gsub!(/suffix\z/, '')
-str.gsub(/suffix$/, '')
-str.gsub!(/suffix$/, '')
 
 str.sub(/suffix\z/, '')
 str.sub!(/suffix\z/, '')
-str.sub(/suffix$/, '')
-str.sub!(/suffix$/, '')
 
 # good
 str.delete_suffix('suffix')
 str.delete_suffix!('suffix')
 ----
+
+==== SafeMultiline: true (default)
+
+[source,ruby]
+----
+# good
+str.gsub(/suffix$/, '')
+str.gsub!(/suffix$/, '')
+str.sub(/suffix$/, '')
+str.sub!(/suffix$/, '')
+----
+
+==== SafeMultiline: false
+
+[source,ruby]
+----
+# bad
+str.gsub(/suffix$/, '')
+str.gsub!(/suffix$/, '')
+str.sub(/suffix$/, '')
+str.sub!(/suffix$/, '')
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| SafeMultiline
+| `true`
+| Boolean
+|===
 
 == Performance/Detect
 
@@ -482,11 +544,14 @@ str.end_with?(var1, var2)
 | Yes
 | Yes (Unsafe)
 | 0.36
-| 0.44
+| 1.6
 |===
 
-This cop identifies unnecessary use of a regex where `String#end_with?`
-would suffice.
+This cop identifies unnecessary use of a regex where `String#end_with?` would suffice.
+
+This cop has `SafeMultiline` configuration option that `true` by default because
+`end$` is unsafe as it will behave incompatible with `end_with?`
+for receiver is multiline string.
 
 === Examples
 
@@ -500,15 +565,34 @@ would suffice.
 'abc'.match(/bc\Z/)
 /bc\Z/.match('abc')
 
+# good
+'abc'.end_with?('bc')
+----
+
+==== SafeMultiline: true (default)
+
+[source,ruby]
+----
+# good
 'abc'.match?(/bc$/)
 /bc$/.match?('abc')
 'abc' =~ /bc$/
 /bc$/ =~ 'abc'
 'abc'.match(/bc$/)
 /bc$/.match('abc')
+----
 
-# good
-'abc'.end_with?('bc')
+==== SafeMultiline: false
+
+[source,ruby]
+----
+# bad
+'abc'.match?(/bc$/)
+/bc$/.match?('abc')
+'abc' =~ /bc$/
+/bc$/ =~ 'abc'
+'abc'.match(/bc$/)
+/bc$/.match('abc')
 ----
 
 === Configurable attributes
@@ -518,6 +602,10 @@ would suffice.
 
 | AutoCorrect
 | `false`
+| Boolean
+
+| SafeMultiline
+| `true`
 | Boolean
 |===
 
@@ -1057,11 +1145,14 @@ have been assigned to an array or a hash.
 | Yes
 | Yes (Unsafe)
 | 0.36
-| 0.44
+| 1.6
 |===
 
-This cop identifies unnecessary use of a regex where
-`String#start_with?` would suffice.
+This cop identifies unnecessary use of a regex where `String#start_with?` would suffice.
+
+This cop has `SafeMultiline` configuration option that `true` by default because
+`^start` is unsafe as it will behave incompatible with `start_with?`
+for receiver is multiline string.
 
 === Examples
 
@@ -1075,15 +1166,34 @@ This cop identifies unnecessary use of a regex where
 'abc'.match(/\Aab/)
 /\Aab/.match('abc')
 
+# good
+'abc'.start_with?('ab')
+----
+
+==== SafeMultiline: true (default)
+
+[source,ruby]
+----
+# good
 'abc'.match?(/^ab/)
 /^ab/.match?('abc')
 'abc' =~ /^ab/
 /^ab/ =~ 'abc'
 'abc'.match(/^ab/)
 /^ab/.match('abc')
+----
 
-# good
-'abc'.start_with?('ab')
+==== SafeMultiline: false
+
+[source,ruby]
+----
+# bad
+'abc'.match?(/^ab/)
+/^ab/.match?('abc')
+'abc' =~ /^ab/
+/^ab/ =~ 'abc'
+'abc'.match(/^ab/)
+/^ab/.match('abc')
 ----
 
 === Configurable attributes
@@ -1093,6 +1203,10 @@ This cop identifies unnecessary use of a regex where
 
 | AutoCorrect
 | `false`
+| Boolean
+
+| SafeMultiline
+| `true`
 | Boolean
 |===
 

--- a/lib/rubocop/cop/mixin/regexp_metacharacter.rb
+++ b/lib/rubocop/cop/mixin/regexp_metacharacter.rb
@@ -4,21 +4,52 @@ module RuboCop
   module Cop
     # Common functionality for handling regexp metacharacters.
     module RegexpMetacharacter
-      def literal_at_start?(regex_str)
+      private
+
+      def literal_at_start?(regexp)
+        return true if literal_at_start_with_backslash_a?(regexp)
+
+        !safe_multiline? && literal_at_start_with_caret?(regexp)
+      end
+
+      def literal_at_end?(regexp)
+        return true if literal_at_end_with_backslash_z?(regexp)
+
+        !safe_multiline? && literal_at_end_with_dollar?(regexp)
+      end
+
+      def literal_at_start_with_backslash_a?(regex_str)
         # is this regexp 'literal' in the sense of only matching literal
         # chars, rather than using metachars like `.` and `*` and so on?
         # also, is it anchored at the start of the string?
         # (tricky: \s, \d, and so on are metacharacters, but other characters
         #  escaped with a slash are just literals. LITERAL_REGEX takes all
         #  that into account.)
-        regex_str =~ /\A(\\A|\^)(?:#{Util::LITERAL_REGEX})+\z/
+        /\A\\A(?:#{Util::LITERAL_REGEX})+\z/.match?(regex_str)
       end
 
-      def literal_at_end?(regex_str)
+      def literal_at_start_with_caret?(regex_str)
+        # is this regexp 'literal' in the sense of only matching literal
+        # chars, rather than using metachars like `.` and `*` and so on?
+        # also, is it anchored at the start of the string?
+        # (tricky: \s, \d, and so on are metacharacters, but other characters
+        #  escaped with a slash are just literals. LITERAL_REGEX takes all
+        #  that into account.)
+        /\A\^(?:#{Util::LITERAL_REGEX})+\z/.match?(regex_str)
+      end
+
+      def literal_at_end_with_backslash_z?(regex_str)
         # is this regexp 'literal' in the sense of only matching literal
         # chars, rather than using metachars like . and * and so on?
         # also, is it anchored at the end of the string?
-        regex_str =~ /\A(?:#{Util::LITERAL_REGEX})+(\\z|\$)\z/
+        /\A(?:#{Util::LITERAL_REGEX})+\\z\z/.match?(regex_str)
+      end
+
+      def literal_at_end_with_dollar?(regex_str)
+        # is this regexp 'literal' in the sense of only matching literal
+        # chars, rather than using metachars like . and * and so on?
+        # also, is it anchored at the end of the string?
+        /\A(?:#{Util::LITERAL_REGEX})+\$\z/.match?(regex_str)
       end
 
       def drop_start_metacharacter(regexp_string)
@@ -35,6 +66,10 @@ module RuboCop
         else
           regexp_string.chop # drop `$` anchor
         end
+      end
+
+      def safe_multiline?
+        cop_config.fetch('SafeMultiline', true)
       end
     end
   end

--- a/lib/rubocop/cop/performance/delete_prefix.rb
+++ b/lib/rubocop/cop/performance/delete_prefix.rb
@@ -8,25 +8,40 @@ module RuboCop
       # This cop identifies places where `gsub(/\Aprefix/, '')` and `sub(/\Aprefix/, '')`
       # can be replaced by `delete_prefix('prefix')`.
       #
-      # The `delete_prefix('prefix')` method is faster than
-      # `gsub(/\Aprefix/, '')`.
+      # This cop has `SafeMultiline` configuration option that `true` by default because
+      # `^prefix` is unsafe as it will behave incompatible with `delete_prefix`
+      # for receiver is multiline string.
+      #
+      # The `delete_prefix('prefix')` method is faster than `gsub(/\Aprefix/, '')`.
       #
       # @example
       #
       #   # bad
       #   str.gsub(/\Aprefix/, '')
       #   str.gsub!(/\Aprefix/, '')
-      #   str.gsub(/^prefix/, '')
-      #   str.gsub!(/^prefix/, '')
       #
       #   str.sub(/\Aprefix/, '')
       #   str.sub!(/\Aprefix/, '')
-      #   str.sub(/^prefix/, '')
-      #   str.sub!(/^prefix/, '')
       #
       #   # good
       #   str.delete_prefix('prefix')
       #   str.delete_prefix!('prefix')
+      #
+      # @example SafeMultiline: true (default)
+      #
+      #   # good
+      #   str.gsub(/^prefix/, '')
+      #   str.gsub!(/^prefix/, '')
+      #   str.sub(/^prefix/, '')
+      #   str.sub!(/^prefix/, '')
+      #
+      # @example SafeMultiline: false
+      #
+      #   # bad
+      #   str.gsub(/^prefix/, '')
+      #   str.gsub!(/^prefix/, '')
+      #   str.sub(/^prefix/, '')
+      #   str.sub!(/^prefix/, '')
       #
       class DeletePrefix < Cop
         extend TargetRubyVersion

--- a/lib/rubocop/cop/performance/delete_suffix.rb
+++ b/lib/rubocop/cop/performance/delete_suffix.rb
@@ -8,25 +8,40 @@ module RuboCop
       # This cop identifies places where `gsub(/suffix\z/, '')` and `sub(/suffix\z/, '')`
       # can be replaced by `delete_suffix('suffix')`.
       #
-      # The `delete_suffix('suffix')` method is faster than
-      # `gsub(/suffix\z/, '')`.
+      # This cop has `SafeMultiline` configuration option that `true` by default because
+      # `suffix$` is unsafe as it will behave incompatible with `delete_suffix?`
+      # for receiver is multiline string.
+      #
+      # The `delete_suffix('suffix')` method is faster than `gsub(/suffix\z/, '')`.
       #
       # @example
       #
       #   # bad
       #   str.gsub(/suffix\z/, '')
       #   str.gsub!(/suffix\z/, '')
-      #   str.gsub(/suffix$/, '')
-      #   str.gsub!(/suffix$/, '')
       #
       #   str.sub(/suffix\z/, '')
       #   str.sub!(/suffix\z/, '')
-      #   str.sub(/suffix$/, '')
-      #   str.sub!(/suffix$/, '')
       #
       #   # good
       #   str.delete_suffix('suffix')
       #   str.delete_suffix!('suffix')
+      #
+      # @example SafeMultiline: true (default)
+      #
+      #   # good
+      #   str.gsub(/suffix$/, '')
+      #   str.gsub!(/suffix$/, '')
+      #   str.sub(/suffix$/, '')
+      #   str.sub!(/suffix$/, '')
+      #
+      # @example SafeMultiline: false
+      #
+      #   # bad
+      #   str.gsub(/suffix$/, '')
+      #   str.gsub!(/suffix$/, '')
+      #   str.sub(/suffix$/, '')
+      #   str.sub!(/suffix$/, '')
       #
       class DeleteSuffix < Cop
         extend TargetRubyVersion

--- a/lib/rubocop/cop/performance/end_with.rb
+++ b/lib/rubocop/cop/performance/end_with.rb
@@ -3,8 +3,11 @@
 module RuboCop
   module Cop
     module Performance
-      # This cop identifies unnecessary use of a regex where `String#end_with?`
-      # would suffice.
+      # This cop identifies unnecessary use of a regex where `String#end_with?` would suffice.
+      #
+      # This cop has `SafeMultiline` configuration option that `true` by default because
+      # `end$` is unsafe as it will behave incompatible with `end_with?`
+      # for receiver is multiline string.
       #
       # @example
       #   # bad
@@ -15,6 +18,12 @@ module RuboCop
       #   'abc'.match(/bc\Z/)
       #   /bc\Z/.match('abc')
       #
+      #   # good
+      #   'abc'.end_with?('bc')
+      #
+      # @example SafeMultiline: true (default)
+      #
+      #   # good
       #   'abc'.match?(/bc$/)
       #   /bc$/.match?('abc')
       #   'abc' =~ /bc$/
@@ -22,8 +31,16 @@ module RuboCop
       #   'abc'.match(/bc$/)
       #   /bc$/.match('abc')
       #
-      #   # good
-      #   'abc'.end_with?('bc')
+      # @example SafeMultiline: false
+      #
+      #   # bad
+      #   'abc'.match?(/bc$/)
+      #   /bc$/.match?('abc')
+      #   'abc' =~ /bc$/
+      #   /bc$/ =~ 'abc'
+      #   'abc'.match(/bc$/)
+      #   /bc$/.match('abc')
+      #
       class EndWith < Cop
         include RegexpMetacharacter
 

--- a/lib/rubocop/cop/performance/start_with.rb
+++ b/lib/rubocop/cop/performance/start_with.rb
@@ -3,8 +3,11 @@
 module RuboCop
   module Cop
     module Performance
-      # This cop identifies unnecessary use of a regex where
-      # `String#start_with?` would suffice.
+      # This cop identifies unnecessary use of a regex where `String#start_with?` would suffice.
+      #
+      # This cop has `SafeMultiline` configuration option that `true` by default because
+      # `^start` is unsafe as it will behave incompatible with `start_with?`
+      # for receiver is multiline string.
       #
       # @example
       #   # bad
@@ -15,6 +18,12 @@ module RuboCop
       #   'abc'.match(/\Aab/)
       #   /\Aab/.match('abc')
       #
+      #   # good
+      #   'abc'.start_with?('ab')
+      #
+      # @example SafeMultiline: true (default)
+      #
+      #   # good
       #   'abc'.match?(/^ab/)
       #   /^ab/.match?('abc')
       #   'abc' =~ /^ab/
@@ -22,8 +31,16 @@ module RuboCop
       #   'abc'.match(/^ab/)
       #   /^ab/.match('abc')
       #
-      #   # good
-      #   'abc'.start_with?('ab')
+      # @example SafeMultiline: false
+      #
+      #   # bad
+      #   'abc'.match?(/^ab/)
+      #   /^ab/.match?('abc')
+      #   'abc' =~ /^ab/
+      #   /^ab/ =~ 'abc'
+      #   'abc'.match(/^ab/)
+      #   /^ab/.match('abc')
+      #
       class StartWith < Cop
         include RegexpMetacharacter
 

--- a/spec/rubocop/cop/performance/delete_prefix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_prefix_spec.rb
@@ -3,6 +3,9 @@
 RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
   subject(:cop) { described_class.new(config) }
 
+  let(:cop_config) { { 'SafeMultiline' => safe_multiline } }
+  let(:safe_multiline) { true }
+
   context 'TargetRubyVersion <= 2.4', :ruby24 do
     it "does not register an offense when using `gsub(/\Aprefix/, '')`" do
       expect_no_offenses(<<~RUBY)
@@ -77,48 +80,80 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
     end
 
     context 'when using `^` as starting pattern' do
-      it 'registers an offense and corrects when using `gsub`' do
-        expect_offense(<<~RUBY)
-          str.gsub(/^prefix/, '')
-              ^^^^ Use `delete_prefix` instead of `gsub`.
-        RUBY
+      context 'when `SafeMultiline: true`' do
+        let(:safe_multiline) { true }
 
-        expect_correction(<<~RUBY)
-          str.delete_prefix('prefix')
-        RUBY
+        it 'does not register an offense and corrects when using `gsub`' do
+          expect_no_offenses(<<~RUBY)
+            str.gsub(/^prefix/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `gsub!`' do
+          expect_no_offenses(<<~RUBY)
+            str.gsub!(/^prefix/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `sub`' do
+          expect_no_offenses(<<~RUBY)
+            str.sub(/^prefix/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `sub!`' do
+          expect_no_offenses(<<~RUBY)
+            str.sub!(/^prefix/, '')
+          RUBY
+        end
       end
 
-      it 'registers an offense and corrects when using `gsub!`' do
-        expect_offense(<<~RUBY)
-          str.gsub!(/^prefix/, '')
-              ^^^^^ Use `delete_prefix!` instead of `gsub!`.
-        RUBY
+      context 'when `SafeMultiline: false`' do
+        let(:safe_multiline) { false }
 
-        expect_correction(<<~RUBY)
-          str.delete_prefix!('prefix')
-        RUBY
-      end
+        it 'registers an offense and corrects when using `gsub`' do
+          expect_offense(<<~RUBY)
+            str.gsub(/^prefix/, '')
+                ^^^^ Use `delete_prefix` instead of `gsub`.
+          RUBY
 
-      it 'registers an offense and corrects when using `sub`' do
-        expect_offense(<<~RUBY)
-          str.sub(/^prefix/, '')
-              ^^^ Use `delete_prefix` instead of `sub`.
-        RUBY
+          expect_correction(<<~RUBY)
+            str.delete_prefix('prefix')
+          RUBY
+        end
 
-        expect_correction(<<~RUBY)
-          str.delete_prefix('prefix')
-        RUBY
-      end
+        it 'registers an offense and corrects when using `gsub!`' do
+          expect_offense(<<~RUBY)
+            str.gsub!(/^prefix/, '')
+                ^^^^^ Use `delete_prefix!` instead of `gsub!`.
+          RUBY
 
-      it 'registers an offense and corrects when using `sub!`' do
-        expect_offense(<<~RUBY)
-          str.sub!(/^prefix/, '')
-              ^^^^ Use `delete_prefix!` instead of `sub!`.
-        RUBY
+          expect_correction(<<~RUBY)
+            str.delete_prefix!('prefix')
+          RUBY
+        end
 
-        expect_correction(<<~RUBY)
-          str.delete_prefix!('prefix')
-        RUBY
+        it 'registers an offense and corrects when using `sub`' do
+          expect_offense(<<~RUBY)
+            str.sub(/^prefix/, '')
+                ^^^ Use `delete_prefix` instead of `sub`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_prefix('prefix')
+          RUBY
+        end
+
+        it 'registers an offense and corrects when using `sub!`' do
+          expect_offense(<<~RUBY)
+            str.sub!(/^prefix/, '')
+                ^^^^ Use `delete_prefix!` instead of `sub!`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_prefix!('prefix')
+          RUBY
+        end
       end
     end
 

--- a/spec/rubocop/cop/performance/delete_suffix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_suffix_spec.rb
@@ -3,6 +3,9 @@
 RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
   subject(:cop) { described_class.new(config) }
 
+  let(:cop_config) { { 'SafeMultiline' => safe_multiline } }
+  let(:safe_multiline) { true }
+
   context 'TargetRubyVersion <= 2.4', :ruby24 do
     it "does not register an offense when using `gsub(/suffix\z/, '')`" do
       expect_no_offenses(<<~RUBY)
@@ -77,48 +80,80 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
     end
 
     context 'when using `$` as ending pattern' do
-      it 'registers an offense and corrects when using `gsub`' do
-        expect_offense(<<~RUBY)
-          str.gsub(/suffix$/, '')
-              ^^^^ Use `delete_suffix` instead of `gsub`.
-        RUBY
+      context 'when `SafeMultiline: true`' do
+        let(:safe_multiline) { true }
 
-        expect_correction(<<~RUBY)
-          str.delete_suffix('suffix')
-        RUBY
+        it 'does not register an offense and corrects when using `gsub`' do
+          expect_no_offenses(<<~RUBY)
+            str.gsub(/suffix$/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `gsub!`' do
+          expect_no_offenses(<<~RUBY)
+            str.gsub!(/suffix$/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `sub`' do
+          expect_no_offenses(<<~RUBY)
+            str.sub(/suffix$/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `sub!`' do
+          expect_no_offenses(<<~RUBY)
+            str.sub!(/suffix$/, '')
+          RUBY
+        end
       end
 
-      it 'registers an offense and corrects when using `gsub!`' do
-        expect_offense(<<~RUBY)
-          str.gsub!(/suffix$/, '')
-              ^^^^^ Use `delete_suffix!` instead of `gsub!`.
-        RUBY
+      context 'when `SafeMultiline: false`' do
+        let(:safe_multiline) { false }
 
-        expect_correction(<<~RUBY)
-          str.delete_suffix!('suffix')
-        RUBY
-      end
+        it 'registers an offense and corrects when using `gsub`' do
+          expect_offense(<<~RUBY)
+            str.gsub(/suffix$/, '')
+                ^^^^ Use `delete_suffix` instead of `gsub`.
+          RUBY
 
-      it 'registers an offense and corrects when using `sub`' do
-        expect_offense(<<~RUBY)
-          str.sub(/suffix$/, '')
-              ^^^ Use `delete_suffix` instead of `sub`.
-        RUBY
+          expect_correction(<<~RUBY)
+            str.delete_suffix('suffix')
+          RUBY
+        end
 
-        expect_correction(<<~RUBY)
-          str.delete_suffix('suffix')
-        RUBY
-      end
+        it 'registers an offense and corrects when using `gsub!`' do
+          expect_offense(<<~RUBY)
+            str.gsub!(/suffix$/, '')
+                ^^^^^ Use `delete_suffix!` instead of `gsub!`.
+          RUBY
 
-      it 'registers an offense and corrects when using `sub!`' do
-        expect_offense(<<~RUBY)
-          str.sub!(/suffix$/, '')
-              ^^^^ Use `delete_suffix!` instead of `sub!`.
-        RUBY
+          expect_correction(<<~RUBY)
+            str.delete_suffix!('suffix')
+          RUBY
+        end
 
-        expect_correction(<<~RUBY)
-          str.delete_suffix!('suffix')
-        RUBY
+        it 'registers an offense and corrects when using `sub`' do
+          expect_offense(<<~RUBY)
+            str.sub(/suffix$/, '')
+                ^^^ Use `delete_suffix` instead of `sub`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_suffix('suffix')
+          RUBY
+        end
+
+        it 'registers an offense and corrects when using `sub!`' do
+          expect_offense(<<~RUBY)
+            str.sub!(/suffix$/, '')
+                ^^^^ Use `delete_suffix!` instead of `sub!`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_suffix!('suffix')
+          RUBY
+        end
       end
     end
 

--- a/spec/rubocop/cop/performance/end_with_spec.rb
+++ b/spec/rubocop/cop/performance/end_with_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Performance::EndWith do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Performance::EndWith, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:cop_config) { { 'SafeMultiline' => safe_multiline } }
 
   shared_examples 'different match methods' do |method|
     it "autocorrects str#{method} /abc\\z/" do
@@ -129,11 +131,25 @@ RSpec.describe RuboCop::Cop::Performance::EndWith do
     end
   end
 
-  include_examples('different match methods', '.match?')
-  include_examples('different match methods', ' =~')
-  include_examples('different match methods', '.match')
+  context 'when `SafeMultiline: false`' do
+    let(:safe_multiline) { false }
 
-  it 'allows match without a receiver' do
-    expect_no_offenses('expect(subject.spin).to match(/\n\z/)')
+    include_examples('different match methods', '.match?')
+    include_examples('different match methods', ' =~')
+    include_examples('different match methods', '.match')
+
+    it 'allows match without a receiver' do
+      expect_no_offenses('expect(subject.spin).to match(/\n\z/)')
+    end
+  end
+
+  context 'when `SafeMultiline: true`' do
+    let(:safe_multiline) { true }
+
+    it 'does not register an offense using `$` as ending pattern' do
+      expect_no_offenses(<<~RUBY)
+        'abc'.match?(/ab$/)
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/performance/start_with_spec.rb
+++ b/spec/rubocop/cop/performance/start_with_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Performance::StartWith do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Performance::StartWith, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:cop_config) { { 'SafeMultiline' => safe_multiline } }
 
   shared_examples 'different match methods' do |method|
     it "autocorrects str#{method} /\\Aabc/" do
@@ -109,11 +111,25 @@ RSpec.describe RuboCop::Cop::Performance::StartWith do
     end
   end
 
-  include_examples('different match methods', '.match?')
-  include_examples('different match methods', ' =~')
-  include_examples('different match methods', '.match')
+  context 'when `SafeMultiline: false`' do
+    let(:safe_multiline) { false }
 
-  it 'allows match without a receiver' do
-    expect_no_offenses('expect(subject.spin).to match(/\A\n/)')
+    include_examples('different match methods', '.match?')
+    include_examples('different match methods', ' =~')
+    include_examples('different match methods', '.match')
+
+    it 'allows match without a receiver' do
+      expect_no_offenses('expect(subject.spin).to match(/\A\n/)')
+    end
+  end
+
+  context 'when `SafeMultiline: true`' do
+    let(:safe_multiline) { true }
+
+    it 'does not register an offense when using `^` as starting pattern' do
+      expect_no_offenses(<<~RUBY)
+        'abc'.match?(/^ab/)
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #118.

Fix a false positive for `Performance/DeletePrefix`, `Performance/DeletePrefix`, `Performance/StartWith`, and `Performance/EndWith` cops when receiver is multiline string.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
