### PR TITLE
Add new `Performance/AncestorsInclude` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#123](https://github.com/rubocop-hq/rubocop-performance/pull/123): Add new `Performance/AncestorsInclude` cop. ([@fatkodima][])
 * [#125](https://github.com/rubocop-hq/rubocop-performance/pull/125): Support `Range#member?` method for `Performance/RangeInclude` cop. ([@fatkodima][])
 
 ## 1.6.1 (2020-06-05)

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,11 @@
 # This is the default configuration file.
 
+Performance/AncestorsInclude:
+  Description: 'Use `A <= B` instead of `A.ancestors.include?(B)`.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#ancestorsinclude-vs--code'
+  Enabled: true
+  VersionAdded: '1.7'
+
 Performance/BindCall:
   Description: 'Use `bind_call(obj, args, ...)` instead of `bind(obj).call(args, ...)`.'
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -2,6 +2,7 @@
 
 = Department xref:cops_performance.adoc[Performance]
 
+* xref:cops_performance.adoc#performanceancestorsinclude[Performance/AncestorsInclude]
 * xref:cops_performance.adoc#performancebindcall[Performance/BindCall]
 * xref:cops_performance.adoc#performancecaller[Performance/Caller]
 * xref:cops_performance.adoc#performancecasewhensplat[Performance/CaseWhenSplat]

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1,5 +1,35 @@
 = Performance
 
+== Performance/AncestorsInclude
+
+|===
+| Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+
+| Enabled
+| Yes
+| Yes
+| 1.7
+| -
+|===
+
+This cop is used to identify usages of `ancestors.include?` and
+change them to use `<=` instead.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+A.ancestors.include?(B)
+
+# good
+A <= B
+----
+
+=== References
+
+* https://github.com/JuanitoFatas/fast-ruby#ancestorsinclude-vs--code
+
 == Performance/BindCall
 
 NOTE: Required Ruby version: 2.7

--- a/lib/rubocop/cop/performance/ancestors_include.rb
+++ b/lib/rubocop/cop/performance/ancestors_include.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Performance
+      # This cop is used to identify usages of `ancestors.include?` and
+      # change them to use `<=` instead.
+      #
+      # @example
+      #   # bad
+      #   A.ancestors.include?(B)
+      #
+      #   # good
+      #   A <= B
+      #
+      class AncestorsInclude < Cop
+        include RangeHelp
+
+        MSG = 'Use `<=` instead of `ancestors.include?`.'
+
+        def_node_matcher :ancestors_include_candidate?, <<~PATTERN
+          (send (send $_subclass :ancestors) :include? $_superclass)
+        PATTERN
+
+        def on_send(node)
+          return unless ancestors_include_candidate?(node)
+
+          location_of_ancestors = node.children[0].loc.selector.begin_pos
+          end_location = node.loc.selector.end_pos
+          range = range_between(location_of_ancestors, end_location)
+
+          add_offense(node, location: range)
+        end
+
+        def autocorrect(node)
+          ancestors_include_candidate?(node) do |subclass, superclass|
+            lambda do |corrector|
+              corrector.replace(node, "#{subclass.source} <= #{superclass.source}")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/performance_cops.rb
+++ b/lib/rubocop/cop/performance_cops.rb
@@ -2,6 +2,7 @@
 
 require_relative 'mixin/regexp_metacharacter'
 
+require_relative 'performance/ancestors_include'
 require_relative 'performance/bind_call'
 require_relative 'performance/caller'
 require_relative 'performance/case_when_splat'

--- a/spec/rubocop/cop/performance/ancestors_include_spec.rb
+++ b/spec/rubocop/cop/performance/ancestors_include_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Performance::AncestorsInclude do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense and corrects when using `ancestors.include?`' do
+    expect_offense(<<~RUBY)
+      Class.ancestors.include?(Kernel)
+            ^^^^^^^^^^^^^^^^^^ Use `<=` instead of `ancestors.include?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Class <= Kernel
+    RUBY
+  end
+
+  it 'does not register an offense when using `<=`' do
+    expect_no_offenses(<<~RUBY)
+      Class <= Kernel
+    RUBY
+  end
+end


### PR DESCRIPTION
Related link - https://github.com/JuanitoFatas/fast-ruby#ancestorsinclude-vs--code

### Benchmark

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

def fast
  (Class <= Class)
  (Class <= Module)
  (Class <= Object)
  (Class <= Kernel)
  (Class <= BasicObject)
end

def slow
  Class.ancestors.include?(Class)
  Class.ancestors.include?(Module)
  Class.ancestors.include?(Object)
  Class.ancestors.include?(Kernel)
  Class.ancestors.include?(BasicObject)
end

puts('********* IPS *********')

Benchmark.ips do |x|
  x.report('less than or equal') { fast }
  x.report('ancestors.include?') { slow }
  x.compare!
end

puts "********* MEMORY *********"

Benchmark.memory do |x|
  x.report('less than or equal') { fast }
  x.report('ancestors.include?') { slow }
  x.compare!
end
```

### Results

```
********* IPS *********
Warming up --------------------------------------
  less than or equal   444.389k i/100ms
  ancestors.include?    67.737k i/100ms
Calculating -------------------------------------
  less than or equal      4.947M (± 5.9%) i/s -     24.886M in   5.049943s
  ancestors.include?    641.527k (±27.5%) i/s -      2.709M in   5.082782s

Comparison:
  less than or equal:  4947152.6 i/s
  ancestors.include?:   641526.9 i/s - 7.71x  (± 0.00) slower

********* MEMORY *********
Calculating -------------------------------------
  less than or equal     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
  ancestors.include?     1.000k memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
  less than or equal:          0 allocated
  ancestors.include?:       1000 allocated - Infx more
```