### PR TITLE
Add new `Performance/BigDecimalWithNumericArgument` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#129](https://github.com/rubocop-hq/rubocop-performance/pull/129): Add new `Performance/BigDecimalWithNumericArgument` cop. ([@fatkodima][])
 * [#130](https://github.com/rubocop-hq/rubocop-performance/pull/130): Add new `Performance/SortReverse` cop. ([@fatkodima][])
 * [#81](https://github.com/rubocop-hq/rubocop-performance/issues/81): Add new `Performance/StringInclude` cop. ([@fatkodima][])
 * [#123](https://github.com/rubocop-hq/rubocop-performance/pull/123): Add new `Performance/AncestorsInclude` cop. ([@fatkodima][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,11 @@ Performance/AncestorsInclude:
   Enabled: true
   VersionAdded: '1.7'
 
+Performance/BigDecimalWithNumericArgument:
+  Description: 'Convert numeric argument to string before passing to BigDecimal.'
+  Enabled: true
+  VersionAdded: '1.7'
+
 Performance/BindCall:
   Description: 'Use `bind_call(obj, args, ...)` instead of `bind(obj).call(args, ...)`.'
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -3,6 +3,7 @@
 = Department xref:cops_performance.adoc[Performance]
 
 * xref:cops_performance.adoc#performanceancestorsinclude[Performance/AncestorsInclude]
+* xref:cops_performance.adoc#performancebigdecimalwithnumericargument[Performance/BigDecimalWithNumericArgument]
 * xref:cops_performance.adoc#performancebindcall[Performance/BindCall]
 * xref:cops_performance.adoc#performancecaller[Performance/Caller]
 * xref:cops_performance.adoc#performancecasewhensplat[Performance/CaseWhenSplat]

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -30,6 +30,36 @@ A <= B
 
 * https://github.com/JuanitoFatas/fast-ruby#ancestorsinclude-vs--code
 
+== Performance/BigDecimalWithNumericArgument
+
+|===
+| Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+
+| Enabled
+| Yes
+| Yes
+| 1.7
+| -
+|===
+
+This cop identifies places where numeric argument to BigDecimal should be
+converted to string. Initializing from String is faster
+than from Numeric for BigDecimal.
+
+BigDecimal(1, 2)
+BigDecimal(1.2, 3, exception: true)
+
+  # good
+BigDecimal('1', 2)
+BigDecimal('1.2', 3, exception: true)
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+----
+
 == Performance/BindCall
 
 NOTE: Required Ruby version: 2.7

--- a/lib/rubocop/cop/performance/big_decimal_with_numeric_argument.rb
+++ b/lib/rubocop/cop/performance/big_decimal_with_numeric_argument.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Performance
+      # This cop identifies places where numeric argument to BigDecimal should be
+      # converted to string. Initializing from String is faster
+      # than from Numeric for BigDecimal.
+      #
+      # @example
+      #
+      #   # bad
+      # BigDecimal(1, 2)
+      # BigDecimal(1.2, 3, exception: true)
+      #
+      #   # good
+      # BigDecimal('1', 2)
+      # BigDecimal('1.2', 3, exception: true)
+      #
+      class BigDecimalWithNumericArgument < Cop
+        MSG = 'Convert numeric argument to string before passing to `BigDecimal`.'
+
+        def_node_matcher :big_decimal_with_numeric_argument?, <<~PATTERN
+          (send nil? :BigDecimal $numeric_type? ...)
+        PATTERN
+
+        def on_send(node)
+          big_decimal_with_numeric_argument?(node) do |numeric|
+            add_offense(node, location: numeric.source_range)
+          end
+        end
+
+        def autocorrect(node)
+          big_decimal_with_numeric_argument?(node) do |numeric|
+            lambda do |corrector|
+              corrector.wrap(numeric, "'", "'")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/performance_cops.rb
+++ b/lib/rubocop/cop/performance_cops.rb
@@ -3,6 +3,7 @@
 require_relative 'mixin/regexp_metacharacter'
 
 require_relative 'performance/ancestors_include'
+require_relative 'performance/big_decimal_with_numeric_argument'
 require_relative 'performance/bind_call'
 require_relative 'performance/caller'
 require_relative 'performance/case_when_splat'

--- a/spec/rubocop/cop/performance/big_decimal_with_numeric_argument_spec.rb
+++ b/spec/rubocop/cop/performance/big_decimal_with_numeric_argument_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Performance::BigDecimalWithNumericArgument do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense and corrects when using `BigDecimal` with integer' do
+    expect_offense(<<~RUBY)
+      BigDecimal(1)
+                 ^ Convert numeric argument to string before passing to `BigDecimal`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      BigDecimal('1')
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `BigDecimal` with float' do
+    expect_offense(<<~RUBY)
+      BigDecimal(1.5, 2, exception: true)
+                 ^^^ Convert numeric argument to string before passing to `BigDecimal`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      BigDecimal('1.5', 2, exception: true)
+    RUBY
+  end
+
+  it 'does not register an offense when using `BigDecimal` with string' do
+    expect_no_offenses(<<~RUBY)
+      BigDecimal('1')
+    RUBY
+  end
+end


### PR DESCRIPTION
This is a simple one.

Related link - https://github.com/JuanitoFatas/fast-ruby/pull/172

I believe there is a better name for this cop.

It is faster to pass string argument to `BigDecimal` than numeric arguments.

```ruby
# bad
BigDecimal(1, 2)
BigDecimal(1.2, 3, exception: true)

# good
BigDecimal('1', 2)
BigDecimal('1.2', 3, exception: true)
```

### Benchmark
```ruby
require 'benchmark/ips'
require 'bigdecimal'

Benchmark.ips do |x|
  x.report("BigDecimal('1')")  { BigDecimal('1') }
  x.report("BigDecimal(1)")    { BigDecimal(1) }
  x.compare!
end

Benchmark.ips do |x|
  x.report("BigDecimal('1.0', 2)")  { BigDecimal('1.0', 2) }
  x.report("BigDecimal(1.0, 2)")    { BigDecimal(1.0, 2) }
  x.compare!
end
```

### Results
```
Warming up --------------------------------------
     BigDecimal('1')   179.524k i/100ms
       BigDecimal(1)   114.825k i/100ms
Calculating -------------------------------------
     BigDecimal('1')      1.782M (± 3.9%) i/s -      8.976M in   5.046628s
       BigDecimal(1)      1.107M (± 6.5%) i/s -      5.512M in   5.002115s

Comparison:
     BigDecimal('1'):  1781639.0 i/s
       BigDecimal(1):  1106879.7 i/s - 1.61x  (± 0.00) slower

Warming up --------------------------------------
BigDecimal('1.0', 2)   151.605k i/100ms
  BigDecimal(1.0, 2)    34.490k i/100ms
Calculating -------------------------------------
BigDecimal('1.0', 2)      1.519M (± 4.6%) i/s -      7.580M in   5.001610s
  BigDecimal(1.0, 2)    339.573k (± 5.0%) i/s -      1.724M in   5.093169s

Comparison:
BigDecimal('1.0', 2):  1519109.1 i/s
  BigDecimal(1.0, 2):   339573.1 i/s - 4.47x  (± 0.00) slower
```