### PR TITLE
Fix a build error for `Performance/ChainArrayAllocation`

### DIFF
--- a/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
+++ b/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
@@ -24,22 +24,26 @@ RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
   end
 
   describe 'Methods that require an argument' do
-    it 'first' do
+    it 'does not register an offense for `first.uniq`' do
       # Yes I know this is not valid Ruby
-      inspect_source('[1, 2, 3, 4].first.uniq')
-      expect(cop.messages.empty?).to be(true)
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3, 4].first.uniq
+      RUBY
+    end
 
-      inspect_source('[1, 2, 3, 4].first(10).uniq')
-      expect(cop.messages.empty?).to be(false)
-      expect(cop.messages)
-        .to eq([generate_message('first', 'uniq')])
-      expect(cop.highlights).to eq(['.uniq'])
+    it 'registers an offense for `first(10).uniq`' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3, 4].first(10).uniq
+                              ^^^^^ Use unchained `first!` and `uniq!` (followed by `return array` if required) instead of chaining `first...uniq`.
+      RUBY
+    end
 
-      inspect_source('[1, 2, 3, 4].first(variable).uniq')
-      expect(cop.messages.empty?).to be(false)
-      expect(cop.messages)
-        .to eq([generate_message('first', 'uniq')])
-      expect(cop.highlights).to eq(['.uniq'])
+    it 'registers an offense for `first(variable).uniq`' do
+      expect_offense(<<~RUBY)
+        variable = 42
+        [1, 2, 3, 4].first(variable).uniq
+                                    ^^^^^ Use unchained `first!` and `uniq!` (followed by `return array` if required) instead of chaining `first...uniq`.
+      RUBY
     end
   end
 


### PR DESCRIPTION
This PR fixes the following build error.

```console
Failures:

  1) RuboCop::Cop::Performance::ChainArrayAllocation Methods that
     require an argument first
     Failure/Error: expect(cop.messages.empty?).to be(false)

       expected false
            got true
       # ./spec/rubocop/cop/performance/chain_array_allocation_spec.rb:39:in
       `block (3 levels) in <top (required)>'
```

https://circleci.com/gh/rubocop-hq/rubocop-performance/1775

https://github.com/rubocop-hq/rubocop/pull/7868 has detected this wrong test case and this PR fixed it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
