### PR TITLE
Make a safe detection for `Performance/StringInclude`

### DIFF
--- a/lib/rubocop/cop/performance/string_include.rb
+++ b/lib/rubocop/cop/performance/string_include.rb
@@ -22,7 +22,7 @@ module RuboCop
 
         def_node_matcher :redundant_regex?, <<~PATTERN
           {(send $!nil? {:match :=~ :match?} (regexp (str $#literal?) (regopt)))
-           (send (regexp (str $#literal?) (regopt)) {:match :match?} $_)
+           (send (regexp (str $#literal?) (regopt)) {:match :match?} $str)
            (match-with-lvasgn (regexp (str $#literal?) (regopt)) $_)}
         PATTERN
 

--- a/spec/rubocop/cop/performance/string_include_spec.rb
+++ b/spec/rubocop/cop/performance/string_include_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude do
     end
 
     it "autocorrects /abc/#{method} str" do
-      new_source = autocorrect_source("/abc/#{method} str")
-      expect(new_source).to eq "str.include?('abc')"
+      new_source = autocorrect_source("/abc/#{method} 'str'")
+      expect(new_source).to eq "'str'.include?('abc')"
     end
 
     # escapes like "\n"
@@ -24,8 +24,8 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude do
       end
 
       it "autocorrects /\\#{str}#{method} str/" do
-        new_source = autocorrect_source("/\\#{str}/#{method} str")
-        expect(new_source).to eq %{str.include?("\\#{str}")}
+        new_source = autocorrect_source("/\\#{str}/#{method} 'str'")
+        expect(new_source).to eq %{'str'.include?("\\#{str}")}
       end
     end
 
@@ -37,8 +37,8 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude do
       end
 
       it "autocorrects /\\#{str}/#{method} str" do
-        new_source = autocorrect_source("/\\#{str}/#{method} str")
-        expect(new_source).to eq "str.include?('#{str}')"
+        new_source = autocorrect_source("/\\#{str}/#{method} 'str'")
+        expect(new_source).to eq "'str'.include?('#{str}')"
       end
 
       it "doesn't register an error for str#{method} /prefix#{str}/" do
@@ -69,8 +69,8 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude do
       end
 
       it "autocorrects /\\#{str}#{method} str/" do
-        new_source = autocorrect_source("/\\#{str}/#{method} str")
-        expect(new_source).to eq "str.include?('#{str}')"
+        new_source = autocorrect_source("/\\#{str}/#{method} 'str'")
+        expect(new_source).to eq "'str'.include?('#{str}')"
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude do
     end
 
     it "formats the error message correctly for /abc/#{method} str" do
-      inspect_source("/abc/#{method} str")
+      inspect_source("/abc/#{method} 'str'")
       expect(cop.messages).to eq(['Use `String#include?` instead of a regex match with literal-only pattern.'])
     end
 
@@ -90,8 +90,8 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude do
     end
 
     it "autocorrects /\\\\/#{method} str" do
-      new_source = autocorrect_source("/\\\\/#{method} str")
-      expect(new_source).to eq("str.include?('\\\\')")
+      new_source = autocorrect_source("/\\\\/#{method} 'str'")
+      expect(new_source).to eq("'str'.include?('\\\\')")
     end
   end
 
@@ -101,5 +101,12 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude do
 
   it 'allows match without a receiver' do
     expect_no_offenses('expect(subject.spin).to match(/\A\n/)')
+  end
+
+  # Symbol object does not have `include?` method.
+  # A variable possible to be a symbol object, so if `match?` argument is
+  # a variable, accept it.
+  it 'allows argument of `match?` is not a string literal' do
+    expect_no_offenses('/ /.match?(content_as_symbol)')
   end
 end


### PR DESCRIPTION
This PR makes a safe detection for `Performance/StringInclude` cop when `match?` argument is a variable.
Symbol object does not have an `include?` method.

The following is an auto-corrected example code.

```console
% ruby -e ':symbol.include?(/pattern/)'
Traceback (most recent call last):
-e:1:in `<main>': undefined method `include?' for :symbol:Symbol (NoMethodError)
````

A variable possible to be a symbol object, so if `match?` argument is a variable, accept it.

As an unsafe option it might be possible to provide detection when argument is a variable.
First of all, this PR makes detection safe.

This PR haven't added a changelog entry as it is an unreleased feature.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
