### PR TITLE
Add bad example for BigDecimalWithNumericArgument

### DIFF
--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -46,18 +46,17 @@ This cop identifies places where numeric argument to BigDecimal should be
 converted to string. Initializing from String is faster
 than from Numeric for BigDecimal.
 
-BigDecimal(1, 2)
-BigDecimal(1.2, 3, exception: true)
-
-  # good
-BigDecimal('1', 2)
-BigDecimal('1.2', 3, exception: true)
-
 === Examples
 
 [source,ruby]
 ----
 # bad
+BigDecimal(1, 2)
+BigDecimal(1.2, 3, exception: true)
+
+# good
+BigDecimal('1', 2)
+BigDecimal('1.2', 3, exception: true)
 ----
 
 == Performance/BindCall

--- a/lib/rubocop/cop/performance/big_decimal_with_numeric_argument.rb
+++ b/lib/rubocop/cop/performance/big_decimal_with_numeric_argument.rb
@@ -8,14 +8,13 @@ module RuboCop
       # than from Numeric for BigDecimal.
       #
       # @example
-      #
       #   # bad
-      # BigDecimal(1, 2)
-      # BigDecimal(1.2, 3, exception: true)
+      #   BigDecimal(1, 2)
+      #   BigDecimal(1.2, 3, exception: true)
       #
       #   # good
-      # BigDecimal('1', 2)
-      # BigDecimal('1.2', 3, exception: true)
+      #   BigDecimal('1', 2)
+      #   BigDecimal('1.2', 3, exception: true)
       #
       class BigDecimalWithNumericArgument < Cop
         MSG = 'Convert numeric argument to string before passing to `BigDecimal`.'


### PR DESCRIPTION
This PR adds the bad example in documentation for Performance/BigDecimalWithNumericArgument
Ref: [https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancebigdecimalwithnumericargument](https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancebigdecimalwithnumericargument)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
