### PR TITLE
[Fix #147] Fix an error for `Performance/AncestorsInclude`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#147](https://github.com/rubocop-hq/rubocop-performance/issues/147): Fix an error for `Performance/AncestorsInclude` when using `ancestors.include?` without receiver. ([@koic][])
+
 ### Changes
 
 * [#149](https://github.com/rubocop-hq/rubocop-performance/pull/149): Mark `Performance/AncestorsInclude` as unsafe. ([@eugeneius][])

--- a/lib/rubocop/cop/performance/ancestors_include.rb
+++ b/lib/rubocop/cop/performance/ancestors_include.rb
@@ -35,7 +35,9 @@ module RuboCop
         def autocorrect(node)
           ancestors_include_candidate?(node) do |subclass, superclass|
             lambda do |corrector|
-              corrector.replace(node, "#{subclass.source} <= #{superclass.source}")
+              subclass_source = subclass ? subclass.source : 'self'
+
+              corrector.replace(node, "#{subclass_source} <= #{superclass.source}")
             end
           end
         end

--- a/spec/rubocop/cop/performance/ancestors_include_spec.rb
+++ b/spec/rubocop/cop/performance/ancestors_include_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe RuboCop::Cop::Performance::AncestorsInclude do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `ancestors.include?` without receiver' do
+    expect_offense(<<~RUBY)
+      ancestors.include?(Klass)
+      ^^^^^^^^^^^^^^^^^^ Use `<=` instead of `ancestors.include?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      self <= Klass
+    RUBY
+  end
+
   it 'does not register an offense when using `<=`' do
     expect_no_offenses(<<~RUBY)
       Class <= Kernel


### PR DESCRIPTION
Fixes #147.

This PR fixes an error for `Performance/AncestorsInclude` when using `ancestors.include?` without receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
