### PR TITLE
Don't autocorrect BigDecimal with float when precision is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#147](https://github.com/rubocop-hq/rubocop-performance/issues/147): Fix an error for `Performance/AncestorsInclude` when using `ancestors.include?` without receiver. ([@koic][])
+* [#150](https://github.com/rubocop-hq/rubocop-performance/pull/150): Fix an incorrect autocorrect for `Performance/BigDecimalWithNumericArgument` when a precision is specified. ([@eugeneius][])
 
 ### Changes
 

--- a/lib/rubocop/cop/performance/big_decimal_with_numeric_argument.rb
+++ b/lib/rubocop/cop/performance/big_decimal_with_numeric_argument.rb
@@ -25,6 +25,8 @@ module RuboCop
 
         def on_send(node)
           big_decimal_with_numeric_argument?(node) do |numeric|
+            next if numeric.float_type? && specifies_precision?(node)
+
             add_offense(node, location: numeric.source_range)
           end
         end
@@ -35,6 +37,12 @@ module RuboCop
               corrector.wrap(numeric, "'", "'")
             end
           end
+        end
+
+        private
+
+        def specifies_precision?(node)
+          node.arguments.size > 1 && !node.arguments[1].hash_type?
         end
       end
     end

--- a/spec/rubocop/cop/performance/big_decimal_with_numeric_argument_spec.rb
+++ b/spec/rubocop/cop/performance/big_decimal_with_numeric_argument_spec.rb
@@ -16,12 +16,31 @@ RSpec.describe RuboCop::Cop::Performance::BigDecimalWithNumericArgument do
 
   it 'registers an offense and corrects when using `BigDecimal` with float' do
     expect_offense(<<~RUBY)
-      BigDecimal(1.5, 2, exception: true)
+      BigDecimal(1.5, exception: true)
                  ^^^ Convert numeric argument to string before passing to `BigDecimal`.
     RUBY
 
     expect_correction(<<~RUBY)
-      BigDecimal('1.5', 2, exception: true)
+      BigDecimal('1.5', exception: true)
+    RUBY
+  end
+
+  it 'does not register an offense when using `BigDecimal` with float and precision' do
+    expect_no_offenses(<<~RUBY)
+      BigDecimal(3.14, 1)
+    RUBY
+  end
+
+  it 'does not register an offense when using `BigDecimal` with float and non-literal precision' do
+    expect_no_offenses(<<~RUBY)
+      precision = 1
+      BigDecimal(3.14, precision)
+    RUBY
+  end
+
+  it 'does not register an offense when using `BigDecimal` with float, precision, and a keyword argument' do
+    expect_no_offenses(<<~RUBY)
+      BigDecimal(3.14, 1, exception: true)
     RUBY
   end
 


### PR DESCRIPTION
The precision argument to `BigDecimal()` is ignored unless the value is a float or rational. Converting the value from a float to a string when a precision is specified changes the result.

    $ ruby -rbigdecimal -e "puts BigDecimal(3.14, 1)"
    0.3e1

    $ ruby -rbigdecimal -e "puts BigDecimal('3.14', 1)"
    0.314e1

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/