### PR TITLE
[Fix #145] Mark `Performance/StringInclude` as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
 * [#149](https://github.com/rubocop-hq/rubocop-performance/pull/149): Mark `Performance/AncestorsInclude` as unsafe. ([@eugeneius][])
+* [#145](https://github.com/rubocop-hq/rubocop-performance/issues/145): Mark `Performance/StringInclude` as `SafeAutocorrect: false` and disable autocorrect by default. ([@koic][])
 
 ## 1.7.0 (2020-07-07)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -248,6 +248,8 @@ Performance/StartWith:
 Performance/StringInclude:
   Description: 'Use `String#include?` instead of a regex match with literal-only pattern.'
   Enabled: 'pending'
+  AutoCorrect: false
+  SafeAutoCorrect: false
   VersionAdded: '1.7'
 
 Performance/StringReplacement:

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1499,13 +1499,15 @@ for receiver is multiline string.
 
 | Pending
 | Yes
-| Yes
+| Yes (Unsafe)
 | 1.7
 | -
 |===
 
 This cop identifies unnecessary use of a regex where
 `String#include?` would suffice.
+
+This cop's offenses are not safe to auto-correct if a receiver is nil.
 
 === Examples
 
@@ -1522,6 +1524,16 @@ This cop identifies unnecessary use of a regex where
 # good
 'abc'.include?('ab')
 ----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AutoCorrect
+| `false`
+| Boolean
+|===
 
 == Performance/StringReplacement
 

--- a/lib/rubocop/cop/performance/string_include.rb
+++ b/lib/rubocop/cop/performance/string_include.rb
@@ -6,6 +6,8 @@ module RuboCop
       # This cop identifies unnecessary use of a regex where
       # `String#include?` would suffice.
       #
+      # This cop's offenses are not safe to auto-correct if a receiver is nil.
+      #
       # @example
       #   # bad
       #   'abc'.match?(/ab/)


### PR DESCRIPTION
Fixes #145.

This PR marks `Performance/StringInclude` as `SafeAutocorrect: false` and disable autocorrect by default. The cop's offenses are not safe to auto-correct if a receiver is nil.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
