### PR TITLE
Extend `Performance/Detect` cop with check for `filter` method and `Performance/Count` cop with checks for `find_all` and `filter` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changes
 
+* [#157](https://github.com/rubocop-hq/rubocop-performance/pull/157): Extend `Performance/Detect` cop with check for `filter` method and `Performance/Count` cop with checks for `find_all` and `filter` methods. ([@fatkodima][])
 * [#154](https://github.com/rubocop-hq/rubocop-performance/pull/154): Require RuboCop 0.87 or higher. ([@koic][])
 
 ## 1.7.1 (2020-07-18)

--- a/config/default.yml
+++ b/config/default.yml
@@ -63,16 +63,14 @@ Performance/CompareWithBlock:
 
 Performance/Count:
   Description: >-
-                  Use `count` instead of `select...size`, `reject...size`,
-                  `select...count`, `reject...count`, `select...length`,
-                  and `reject...length`.
+                  Use `count` instead of `{select,find_all,filter,reject}...{size,count,length}`.
   # This cop has known compatibility issues with `ActiveRecord` and other
   # frameworks. ActiveRecord's `count` ignores the block that is passed to it.
   # For more information, see the documentation in the cop itself.
   SafeAutoCorrect: false
   Enabled: true
   VersionAdded: '0.31'
-  VersionChanged: '1.5'
+  VersionChanged: '1.8'
 
 Performance/DeletePrefix:
   Description: 'Use `delete_prefix` instead of `gsub`.'
@@ -88,8 +86,8 @@ Performance/DeleteSuffix:
 
 Performance/Detect:
   Description: >-
-                  Use `detect` instead of `select.first`, `find_all.first`,
-                  `select.last`, and `find_all.last`.
+                  Use `detect` instead of `select.first`, `find_all.first`, `filter.first`,
+                  `select.last`, `find_all.last`, and `filter.last`.
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
   # This cop has known compatibility issues with `ActiveRecord` and other
   # frameworks. `ActiveRecord` does not implement a `detect` method and `find`
@@ -98,7 +96,7 @@ Performance/Detect:
   SafeAutoCorrect: false
   Enabled: true
   VersionAdded: '0.30'
-  VersionChanged: '1.5'
+  VersionChanged: '1.8'
 
 Performance/DoubleStartEndWith:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -377,11 +377,11 @@ array.sort_by { |a| a[:foo] }
 | Yes
 | Yes (Unsafe)
 | 0.31
-| 1.5
+| 1.8
 |===
 
 This cop is used to identify usages of `count` on an `Enumerable` that
-follow calls to `select` or `reject`. Querying logic can instead be
+follow calls to `select`, `find_all`, `filter` or `reject`. Querying logic can instead be
 passed to the `count` call.
 
 `ActiveRecord` compatibility:
@@ -574,11 +574,11 @@ str.sub!(/suffix$/, '')
 | Yes
 | Yes (Unsafe)
 | 0.30
-| 1.5
+| 1.8
 |===
 
 This cop is used to identify usages of
-`select.first`, `select.last`, `find_all.first`, and `find_all.last`
+`select.first`, `select.last`, `find_all.first`, `find_all.last`, `filter.first`, and `filter.last`
 and change them to use `detect` instead.
 
 `ActiveRecord` compatibility:
@@ -595,6 +595,8 @@ considered unsafe.
 [].select { |item| true }.last
 [].find_all { |item| true }.first
 [].find_all { |item| true }.last
+[].filter { |item| true }.first
+[].filter { |item| true }.last
 
 # good
 [].detect { |item| true }

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Performance
       # This cop is used to identify usages of `count` on an `Enumerable` that
-      # follow calls to `select` or `reject`. Querying logic can instead be
+      # follow calls to `select`, `find_all`, `filter` or `reject`. Querying logic can instead be
       # passed to the `count` call.
       #
       # @example
@@ -45,8 +45,8 @@ module RuboCop
 
         def_node_matcher :count_candidate?, <<~PATTERN
           {
-            (send (block $(send _ ${:select :reject}) ...) ${:count :length :size})
-            (send $(send _ ${:select :reject} (:block_pass _)) ${:count :length :size})
+            (send (block $(send _ ${:select :filter :find_all :reject}) ...) ${:count :length :size})
+            (send $(send _ ${:select :filter :find_all :reject} (:block_pass _)) ${:count :length :size})
           }
         PATTERN
 

--- a/lib/rubocop/cop/performance/detect.rb
+++ b/lib/rubocop/cop/performance/detect.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Performance
       # This cop is used to identify usages of
-      # `select.first`, `select.last`, `find_all.first`, and `find_all.last`
+      # `select.first`, `select.last`, `find_all.first`, `find_all.last`, `filter.first`, and `filter.last`
       # and change them to use `detect` instead.
       #
       # @example
@@ -13,6 +13,8 @@ module RuboCop
       #   [].select { |item| true }.last
       #   [].find_all { |item| true }.first
       #   [].find_all { |item| true }.last
+      #   [].filter { |item| true }.first
+      #   [].filter { |item| true }.last
       #
       #   # good
       #   [].detect { |item| true }
@@ -32,8 +34,8 @@ module RuboCop
 
         def_node_matcher :detect_candidate?, <<~PATTERN
           {
-            (send $(block (send _ {:select :find_all}) ...) ${:first :last} $...)
-            (send $(send _ {:select :find_all} ...) ${:first :last} $...)
+            (send $(block (send _ {:select :find_all :filter}) ...) ${:first :last} $...)
+            (send $(send _ {:select :find_all :filter} ...) ${:first :last} $...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -106,6 +106,8 @@ RSpec.describe RuboCop::Cop::Performance::Count do
   end
 
   it_behaves_like('selectors', 'select')
+  it_behaves_like('selectors', 'find_all')
+  it_behaves_like('selectors', 'filter')
   it_behaves_like('selectors', 'reject')
 
   context 'Active Record select' do

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
 
   # rspec will not let you use a variable assigned using let outside
   # of `it`
-  select_methods = %i[select find_all].freeze
+  select_methods = %i[select find_all filter].freeze
 
   select_methods.each do |method|
     it "registers an offense and corrects when first is called on #{method}" do


### PR DESCRIPTION
Closes #63 

I have rechecked existing `Detect` and `Count` cops - they are handling almost everything that is needed/requested (as mentioned in https://github.com/rubocop-hq/rubocop-performance/issues/63#issuecomment-512884529). 

So implemented checks for 2 missing methods in this PR.  