### PR TITLE
[Fix #159] Fix a false positive for `Performance/AncestorsInclude`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#140](https://github.com/rubocop-hq/rubocop-performance/pull/140): Add new `Performance/CollectionLiteralInLoop` cop. ([@fatkodima][])
 * [#137](https://github.com/rubocop-hq/rubocop-performance/pull/137): Add new `Performance/Sum` cop. ([@fatkodima][])
 
+### Bug fixes
+
+* [#159](https://github.com/rubocop-hq/rubocop-performance/pull/159): Fix a false positive for `Performance/AncestorsInclude` when receiver is a variable. ([@koic][])
+
 ### Changes
 
 * [#154](https://github.com/rubocop-hq/rubocop-performance/pull/154): Require RuboCop 0.87 or higher. ([@koic][])

--- a/lib/rubocop/cop/performance/ancestors_include.rb
+++ b/lib/rubocop/cop/performance/ancestors_include.rb
@@ -25,16 +25,22 @@ module RuboCop
 
         def on_send(node)
           return unless (subclass, superclass = ancestors_include_candidate?(node))
+          return if subclass && !subclass.const_type?
 
-          location_of_ancestors = node.children[0].loc.selector.begin_pos
-          end_location = node.loc.selector.end_pos
-          range = range_between(location_of_ancestors, end_location)
-
-          add_offense(range) do |corrector|
+          add_offense(range(node)) do |corrector|
             subclass_source = subclass ? subclass.source : 'self'
 
             corrector.replace(node, "#{subclass_source} <= #{superclass.source}")
           end
+        end
+
+        private
+
+        def range(node)
+          location_of_ancestors = node.children[0].loc.selector.begin_pos
+          end_location = node.loc.selector.end_pos
+
+          range_between(location_of_ancestors, end_location)
         end
       end
     end

--- a/spec/rubocop/cop/performance/ancestors_include_spec.rb
+++ b/spec/rubocop/cop/performance/ancestors_include_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe RuboCop::Cop::Performance::AncestorsInclude do
     RUBY
   end
 
+  it 'does not register an offense when receiver is not a consntant' do
+    expect_no_offenses(<<~RUBY)
+      expect(object_one.ancestors.include?(object_two)).to eq(true)
+    RUBY
+  end
+
   it 'does not register an offense when using `<=`' do
     expect_no_offenses(<<~RUBY)
       Class <= Kernel


### PR DESCRIPTION
Fixes #159.

This PR fixes a false positive for `Performance/AncestorsInclude` when receiver is a variable.

As the cop's example shows, this change mainly targets when the receiver is a constant. It can cause false negatives, but it may be less than false positives.
And this change may lead to removing unsafe marked by #149.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
