### PR TITLE
Handle Enumerable methods called with no receiver in CollectionLiteralInLoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#164](https://github.com/rubocop-hq/rubocop-performance/pull/164): Fix an error for `Performance/CollectionLiteralInLoop` when a method from `Enumerable` is called with no receiver. ([@eugeneius][])
+
 ## 1.8.0 (2020-09-04)
 
 ### New features

--- a/lib/rubocop/cop/performance/collection_literal_in_loop.rb
+++ b/lib/rubocop/cop/performance/collection_literal_in_loop.rb
@@ -115,7 +115,7 @@ module RuboCop
 
         def node_within_enumerable_loop?(node, ancestor)
           enumerable_loop?(ancestor) do |receiver|
-            receiver != node && !receiver.descendants.include?(node)
+            receiver != node && !receiver&.descendants&.include?(node)
           end
         end
 

--- a/spec/rubocop/cop/performance/collection_literal_in_loop_spec.rb
+++ b/spec/rubocop/cop/performance/collection_literal_in_loop_spec.rb
@@ -145,6 +145,15 @@ RSpec.describe RuboCop::Cop::Performance::CollectionLiteralInLoop, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when the method is called with no receiver' do
+      expect_offense(<<~RUBY)
+        all? do |e|
+          [1, 2, 3].include?(e)
+          ^^^^^^^^^ Avoid immutable Array literals in loops. It is better to extract it into a local variable or a constant.
+        end
+      RUBY
+    end
   end
 
   context 'when not inside loop' do


### PR DESCRIPTION
The test added here demonstrates the problem:

```ruby
$ bundle exec rspec spec/rubocop/cop/performance/collection_literal_in_loop_spec.rb:149
Run options: include {:locations=>{"./spec/rubocop/cop/performance/collection_literal_in_loop_spec.rb"=>[149]}}

Randomized with seed 21526

RuboCop::Cop::Performance::CollectionLiteralInLoop
  when inside one of `Enumerable` loop-like methods
    registers an offense when the method is called with no receiver (FAILED - 1)

Failures:

  1) RuboCop::Cop::Performance::CollectionLiteralInLoop when inside one of `Enumerable` loop-like methods registers an offense when the method is called with no receiver
     Failure/Error: receiver != node && !receiver.descendants.include?(node)

     NoMethodError:
       undefined method `descendants' for nil:NilClass
     # ./lib/rubocop/cop/performance/collection_literal_in_loop.rb:118:in `block in node_within_enumerable_loop?'
     # ./lib/rubocop/cop/performance/collection_literal_in_loop.rb:85:in `enumerable_loop?'
     # ./lib/rubocop/cop/performance/collection_literal_in_loop.rb:117:in `node_within_enumerable_loop?'
     # ./lib/rubocop/cop/performance/collection_literal_in_loop.rb:109:in `loop?'
     # ./lib/rubocop/cop/performance/collection_literal_in_loop.rb:103:in `block in parent_is_loop?'
     # ./lib/rubocop/cop/performance/collection_literal_in_loop.rb:103:in `each'
     # ./lib/rubocop/cop/performance/collection_literal_in_loop.rb:103:in `any?'
     # ./lib/rubocop/cop/performance/collection_literal_in_loop.rb:103:in `parent_is_loop?'
     # ./lib/rubocop/cop/performance/collection_literal_in_loop.rb:82:in `on_send'
     # ./spec/rubocop/cop/performance/collection_literal_in_loop_spec.rb:150:in `block (3 levels) in <top (required)>'

Finished in 0.03141 seconds (files took 0.8423 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/rubocop/cop/performance/collection_literal_in_loop_spec.rb:149 # RuboCop::Cop::Performance::CollectionLiteralInLoop when inside one of `Enumerable` loop-like methods registers an offense when the method is called with no receiver

Randomized with seed 21526
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/