### PR TITLE
[Fix #165] Fix a false positive for `Performance/Sum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#164](https://github.com/rubocop-hq/rubocop-performance/pull/164): Fix an error for `Performance/CollectionLiteralInLoop` when a method from `Enumerable` is called with no receiver. ([@eugeneius][])
+* [#165](https://github.com/rubocop-hq/rubocop-performance/issues/165): Fix a false positive for `Performance/Sum` when using initial value argument is a variable. ([@koic][])
 
 ## 1.8.0 (2020-09-04)
 

--- a/lib/rubocop/cop/performance/sum.rb
+++ b/lib/rubocop/cop/performance/sum.rb
@@ -98,7 +98,7 @@ module RuboCop
 
           unless init.empty?
             init = init.first
-            good_method += "(#{init.source})" if init.source.to_i != 0
+            good_method += "(#{init.source})" unless init.int_type? && init.value.zero?
           end
           good_method
         end

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -37,6 +37,39 @@ RSpec.describe RuboCop::Cop::Performance::Sum do
       RUBY
     end
 
+    it "registers an offense and corrects when using `array.#{method}(0, :+)`" do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method}(0, :+)
+              ^{method}^^^^^^^ Use `sum` instead of `#{method}(0, :+)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.sum
+      RUBY
+    end
+
+    it "registers an offense and corrects when using `array.#{method}(0.0, :+)`" do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method}(0.0, :+)
+              ^{method}^^^^^^^^^ Use `sum(0.0)` instead of `#{method}(0.0, :+)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.sum(0.0)
+      RUBY
+    end
+
+    it "registers an offense and corrects when using `array.#{method}(init, :+)`" do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method}(init, :+)
+              ^{method}^^^^^^^^^^ Use `sum(init)` instead of `#{method}(init, :+)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.sum(init)
+      RUBY
+    end
+
     it 'does not autocorrect when initial value is not provided' do
       expect_offense(<<~RUBY, method: method)
         array.#{method}(:+)


### PR DESCRIPTION
Fixes #165.

This PR fixes a false positive for `Performance/Sum` when using initial value argument is a variable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
