### PR TITLE
[Fix #163] Detect array indexes for `Performance/Detect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#164](https://github.com/rubocop-hq/rubocop-performance/pull/164): Fix an error for `Performance/CollectionLiteralInLoop` when a method from `Enumerable` is called with no receiver. ([@eugeneius][])
 * [#165](https://github.com/rubocop-hq/rubocop-performance/issues/165): Fix a false positive for `Performance/Sum` when using initial value argument is a variable. ([@koic][])
 
+### Changes
+
+* [#163](https://github.com/rubocop-hq/rubocop-performance/pull/163): Change `Performance/Detect` to also detect offenses when index 0 or -1 is used instead (ie. `detect{ ... }[0]`). ([@dvandersluis][])
+
 ## 1.8.0 (2020-09-04)
 
 ### New features
@@ -162,3 +166,4 @@
 [@dischorde]: https://github.com/dischorde
 [@siegfault]: https://github.com/siegfault
 [@fatkodima]: https://github.com/fatkodima
+[@dvandersluis]: https://github.com/dvandersluis

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -577,8 +577,8 @@ str.sub!(/suffix$/, '')
 | 1.8
 |===
 
-This cop is used to identify usages of
-`select.first`, `select.last`, `find_all.first`, `find_all.last`, `filter.first`, and `filter.last`
+This cop is used to identify usages of `first`, `last`, `[0]` or `[-1]`
+chained to `select`, `find_all`, or `find_all`
 and change them to use `detect` instead.
 
 `ActiveRecord` compatibility:
@@ -597,6 +597,8 @@ considered unsafe.
 [].find_all { |item| true }.last
 [].filter { |item| true }.first
 [].filter { |item| true }.last
+[].filter { |item| true }[0]
+[].filter { |item| true }[-1]
 
 # good
 [].detect { |item| true }

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency('rubocop', '>= 0.87.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 0.4.0')
   s.add_development_dependency('simplecov')
 end

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -101,6 +101,28 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
       RUBY
     end
 
+    it "registers an offense with #{method} short syntax and [0]" do
+      expect_offense(<<~RUBY, method: method)
+        [1, 2, 3].#{method}(&:even?)[0]
+                  ^{method}^^^^^^^^^^^^ Use `detect` instead of `#{method}[0]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].detect(&:even?)
+      RUBY
+    end
+
+    it "registers an offense with #{method} short syntax and [0]" do
+      expect_offense(<<~RUBY, method: method)
+        [1, 2, 3].#{method}(&:even?)[-1]
+                  ^{method}^^^^^^^^^^^^^ Use `reverse.detect` instead of `#{method}[-1]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].reverse.detect(&:even?)
+      RUBY
+    end
+
     it "registers an offense when #{method} is called on `lazy` without receiver" do
       expect_offense(<<~RUBY, method: method)
         lazy.#{method}(&:even?).first
@@ -109,6 +131,28 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
 
       expect_correction(<<~RUBY)
         lazy.detect(&:even?)
+      RUBY
+    end
+
+    it "registers an offense and corrects when [0] is called on #{method}" do
+      expect_offense(<<~RUBY, method: method)
+        [1, 2, 3].#{method} { |i| i % 2 == 0 }[0]
+                  ^{method}^^^^^^^^^^^^^^^^^^^^^^ Use `detect` instead of `#{method}[0]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].detect { |i| i % 2 == 0 }
+      RUBY
+    end
+
+    it "registers an offense and corrects when [-1] is called on #{method}" do
+      expect_offense(<<~RUBY, method: method)
+        [1, 2, 3].#{method} { |i| i % 2 == 0 }[-1]
+                  ^{method}^^^^^^^^^^^^^^^^^^^^^^^ Use `reverse.detect` instead of `#{method}[-1]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].reverse.detect { |i| i % 2 == 0 }
       RUBY
     end
 


### PR DESCRIPTION
`[1, 2, 3].detect{ ... }[0]` and `[1, 2, 3].detect{ ... }[-1]` will now be caught and corrected by the cop as if they were `first` and `last`.

Fixes #163.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
