### PR TITLE
Handle inject(&:+) in Performance/Sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
 * [#163](https://github.com/rubocop-hq/rubocop-performance/pull/163): Change `Performance/Detect` to also detect offenses when index 0 or -1 is used instead (ie. `detect{ ... }[0]`). ([@dvandersluis][])
+* [#168](https://github.com/rubocop-hq/rubocop-performance/pull/168): Extend `Performance/Sum` to register an offense for `inject(&:+)`. ([@eugeneius][])
 
 ## 1.8.0 (2020-09-04)
 

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1649,6 +1649,7 @@ in some Enumerable object can be replaced by `Enumerable#sum` method.
 # bad
 [1, 2, 3].inject(:+)
 [1, 2, 3].reduce(10, :+)
+[1, 2, 3].inject(&:+)
 [1, 2, 3].reduce { |acc, elem| acc + elem }
 
 # good

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -70,10 +70,30 @@ RSpec.describe RuboCop::Cop::Performance::Sum do
       RUBY
     end
 
-    it 'does not autocorrect when initial value is not provided' do
+    it 'does not autocorrect `:+` when initial value is not provided' do
       expect_offense(<<~RUBY, method: method)
         array.#{method}(:+)
               ^{method}^^^^ Use `sum` instead of `#{method}(:+)`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it "registers an offense and corrects when using `array.#{method}(0, &:+)`" do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method}(0, &:+)
+              ^{method}^^^^^^^^ Use `sum` instead of `#{method}(0, &:+)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.sum
+      RUBY
+    end
+
+    it 'does not autocorrect `&:+` when initial value is not provided' do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method}(&:+)
+              ^{method}^^^^^ Use `sum` instead of `#{method}(&:+)`.
       RUBY
 
       expect_no_corrections


### PR DESCRIPTION
Followup to https://github.com/rubocop-hq/rubocop-performance/pull/137.

`inject(&:+)` is another slower way to write `sum`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/