### PR TITLE
Handle map { ... }.sum in Performance/Sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#170](https://github.com/rubocop-hq/rubocop-performance/pull/170): Extend `Performance/Sum` to register an offense for `map { ... }.sum`. ([@eugeneius][])
+
 ## 1.8.1 (2020-09-19)
 
 ### Bug fixes

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1651,11 +1651,12 @@ in some Enumerable object can be replaced by `Enumerable#sum` method.
 [1, 2, 3].reduce(10, :+)
 [1, 2, 3].inject(&:+)
 [1, 2, 3].reduce { |acc, elem| acc + elem }
+[1, 2, 3].map { |elem| elem ** 2 }.sum
 
 # good
 [1, 2, 3].sum
 [1, 2, 3].sum(10)
-[1, 2, 3].sum
+[1, 2, 3].sum { |elem| elem ** 2 }
 ----
 
 === References


### PR DESCRIPTION
Followup to https://github.com/rubocop-hq/rubocop-performance/pull/137.

Passing the block directly to `sum` is faster, and avoids allocating an intermediate array.

### Benchmark

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

SCENARIOS = [
  1..10,
  1..1_000,
  1..100_000
]

SCENARIOS.each do |range|
  puts
  puts " #{range.inspect} ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("map { |n| n ** 2 }.sum") { range.map { |n| n ** 2 }.sum }
    x.report("sum { |n| n ** 2 }")     { range.sum { |n| n ** 2 } }

    x.compare!
  end

  Benchmark.memory do |x|
    x.report("map { |n| n ** 2 }.sum") { range.map { |n| n ** 2 }.sum }
    x.report("sum { |n| n ** 2 }")     { range.sum { |n| n ** 2 } }

    x.compare!
  end
end
```

### Results

```
==================================== 1..10 =====================================

Warming up --------------------------------------
map { |n| n ** 2 }.sum
                        84.528k i/100ms
  sum { |n| n ** 2 }    97.509k i/100ms
Calculating -------------------------------------
map { |n| n ** 2 }.sum
                          1.015M (± 7.9%) i/s -      5.072M in   5.035982s
  sum { |n| n ** 2 }      1.225M (± 5.9%) i/s -      6.143M in   5.042741s

Comparison:
  sum { |n| n ** 2 }:  1224975.6 i/s
map { |n| n ** 2 }.sum:  1014535.8 i/s - 1.21x  slower

Calculating -------------------------------------
map { |n| n ** 2 }.sum
                       200.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
  sum { |n| n ** 2 }     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
  sum { |n| n ** 2 }:          0 allocated
map { |n| n ** 2 }.sum:        200 allocated - Infx more

=================================== 1..1000 ====================================

Warming up --------------------------------------
map { |n| n ** 2 }.sum
                         1.233k i/100ms
  sum { |n| n ** 2 }     1.446k i/100ms
Calculating -------------------------------------
map { |n| n ** 2 }.sum
                         13.256k (± 3.5%) i/s -     66.582k in   5.030415s
  sum { |n| n ** 2 }     14.734k (± 1.3%) i/s -     73.746k in   5.005859s

Comparison:
  sum { |n| n ** 2 }:    14734.4 i/s
map { |n| n ** 2 }.sum:    13256.1 i/s - 1.11x  slower

Calculating -------------------------------------
map { |n| n ** 2 }.sum
                        11.840k memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
  sum { |n| n ** 2 }     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
  sum { |n| n ** 2 }:          0 allocated
map { |n| n ** 2 }.sum:      11840 allocated - Infx more

================================== 1..100000 ===================================

Warming up --------------------------------------
map { |n| n ** 2 }.sum
                        12.000  i/100ms
  sum { |n| n ** 2 }    14.000  i/100ms
Calculating -------------------------------------
map { |n| n ** 2 }.sum
                        132.430  (± 2.3%) i/s -    672.000  in   5.076442s
  sum { |n| n ** 2 }    147.826  (± 2.0%) i/s -    742.000  in   5.021156s

Comparison:
  sum { |n| n ** 2 }:      147.8 i/s
map { |n| n ** 2 }.sum:      132.4 i/s - 1.12x  slower

Calculating -------------------------------------
map { |n| n ** 2 }.sum
                         1.022M memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
  sum { |n| n ** 2 }     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
  sum { |n| n ** 2 }:          0 allocated
map { |n| n ** 2 }.sum:    1021592 allocated - Infx more
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/