### PR TITLE
Fix an incorrect autocorrect for Performance/Sum

### DIFF
--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1652,11 +1652,13 @@ in some Enumerable object can be replaced by `Enumerable#sum` method.
 [1, 2, 3].inject(&:+)
 [1, 2, 3].reduce { |acc, elem| acc + elem }
 [1, 2, 3].map { |elem| elem ** 2 }.sum
+[1, 2, 3].collect(&:count).sum(10)
 
 # good
 [1, 2, 3].sum
 [1, 2, 3].sum(10)
 [1, 2, 3].sum { |elem| elem ** 2 }
+[1, 2, 3].sum(10, &:count)
 ----
 
 === References

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -137,6 +137,17 @@ RSpec.describe RuboCop::Cop::Performance::Sum do
 
     it "registers an offense and corrects when using `array.#{method}(&:count).sum(10)`" do
       expect_offense(<<~RUBY, method: method)
+        array.%{method}(&:count).sum(10)
+              ^{method}^^^^^^^^^^^^^^^^^ Use `sum(10) { ... }` instead of `%{method} { ... }.sum(10)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.sum(10, &:count)
+      RUBY
+    end
+
+    it "registers an offense and corrects when using `array.#{method} { elem ** 2 }.sum(10)`" do
+      expect_offense(<<~RUBY, method: method)
         array.%{method} { |elem| elem ** 2 }.sum(10)
               ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `sum(10) { ... }` instead of `%{method} { ... }.sum(10)`.
       RUBY


### PR DESCRIPTION
See https://github.com/rubocop-hq/rubocop-performance/pull/170#issuecomment-696166317.

When `map` is passed a block argument and `sum` is passed an initial value, they need to be combined in the new `sum` call's argument list.

I don't think a changelog entry is necessary since this correction hasn't been released yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/