### PR TITLE
`Performance/Sum` should avoid, or warn about, empty arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#170](https://github.com/rubocop-hq/rubocop-performance/pull/170): Extend `Performance/Sum` to register an offense for `map { ... }.sum`. ([@eugeneius][])
+* [#179](https://github.com/rubocop-hq/rubocop-performance/pull/179): Change `Performance/Sum` to warn about empty arrays, and not register an offense on empty array literals. ([@ghiculescu][])
 
 ## 1.8.1 (2020-09-19)
 
@@ -174,3 +175,4 @@
 [@siegfault]: https://github.com/siegfault
 [@fatkodima]: https://github.com/fatkodima
 [@dvandersluis]: https://github.com/dvandersluis
+[@ghiculescu]: https://github.com/ghiculescu

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::Performance::Sum do
     it 'does not autocorrect `:+` when initial value is not provided' do
       expect_offense(<<~RUBY, method: method)
         array.#{method}(:+)
-              ^{method}^^^^ Use `sum` instead of `#{method}(:+)`.
+              ^{method}^^^^ Use `sum` instead of `#{method}(:+)`, unless calling `#{method}(:+)` on an empty array.
       RUBY
 
       expect_no_corrections
@@ -93,10 +93,26 @@ RSpec.describe RuboCop::Cop::Performance::Sum do
     it 'does not autocorrect `&:+` when initial value is not provided' do
       expect_offense(<<~RUBY, method: method)
         array.#{method}(&:+)
-              ^{method}^^^^^ Use `sum` instead of `#{method}(&:+)`.
+              ^{method}^^^^^ Use `sum` instead of `#{method}(&:+)`, unless calling `#{method}(&:+)` on an empty array.
       RUBY
 
       expect_no_corrections
+    end
+
+    # ideally it would autocorrect to `[1, 2, 3].sum`
+    it 'registers an offense but does not autocorrect on array literals' do
+      expect_offense(<<~RUBY, method: method)
+        [1, 2, 3].#{method}(:+)
+                  ^{method}^^^^ Use `sum` instead of `#{method}(:+)`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not register an offense when the array is empty' do
+      expect_no_offenses(<<~RUBY, method: method)
+        [].#{method}(:+)
+      RUBY
     end
 
     it 'does not register an offense when block does not implement summation' do


### PR DESCRIPTION
Fixes https://github.com/rubocop-hq/rubocop-performance/issues/177

Doesn't fully resolve the issue, since it only works on array literals. But this removes at least one false positive.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
