### PR TITLE
`Performance/CollectionLiteralInLoop` should be `Enabled: 'pending'`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* [#181](https://github.com/rubocop-hq/rubocop-performance/pull/181): Change default configuration for `Performance/CollectionLiteralInLoop` to `Enabled: 'pending'`. ([@ghiculescu][])
 * [#170](https://github.com/rubocop-hq/rubocop-performance/pull/170): Extend `Performance/Sum` to register an offense for `map { ... }.sum`. ([@eugeneius][])
 * [#179](https://github.com/rubocop-hq/rubocop-performance/pull/179): Change `Performance/Sum` to warn about empty arrays, and not register an offense on empty array literals. ([@ghiculescu][])
 * [#180](https://github.com/rubocop-hq/rubocop-performance/pull/180): Require RuboCop 0.90 or higher. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -51,7 +51,7 @@ Performance/ChainArrayAllocation:
 
 Performance/CollectionLiteralInLoop:
   Description: 'Extract Array and Hash literals outside of loops into local variables or constants.'
-  Enabled: true
+  Enabled: 'pending'
   VersionAdded: '1.8'
   # Min number of elements to consider an offense
   MinSize: 1

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -284,7 +284,7 @@ array
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Enabled
+| Pending
 | Yes
 | No
 | 1.8


### PR DESCRIPTION
As noted [here](https://github.com/rubocop-hq/rubocop-performance/pull/140#discussion_r487437198).