### PR TITLE
Fix typo introduced by #167

### DIFF
--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -615,8 +615,8 @@ str.sub!(/suffix$/, '')
 |===
 
 This cop is used to identify usages of `first`, `last`, `[0]` or `[-1]`
-chained to `select`, `find_all`, or `find_all`
-and change them to use `detect` instead.
+chained to `select`, `find_all` or `filter` and change them to use
+`detect` instead.
 
 `ActiveRecord` compatibility:
 `ActiveRecord` does not implement a `detect` method and `find` has its

--- a/lib/rubocop/cop/performance/detect.rb
+++ b/lib/rubocop/cop/performance/detect.rb
@@ -4,8 +4,8 @@ module RuboCop
   module Cop
     module Performance
       # This cop is used to identify usages of `first`, `last`, `[0]` or `[-1]`
-      # chained to `select`, `find_all`, or `find_all`
-      # and change them to use `detect` instead.
+      # chained to `select`, `find_all` or `filter` and change them to use
+      # `detect` instead.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Correct double named `find_all` to `find_all` and `filter` introduced by 382340966b7b065fe463680c73cb56ab4b0ab878.