### PR TITLE
Extend ReverseEach cop to detect reverse.each_with_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#173](https://github.com/rubocop-hq/rubocop-performance/pull/173): Add new `Performance/BlockGivenWithExplicitBlock` cop. ([@fatkodima][])
 * [#151](https://github.com/rubocop-hq/rubocop-performance/issues/151): Add new `Performance/ConstantRegexp` cop. ([@fatkodima][])
+* [#184](https://github.com/rubocop-hq/rubocop-performance/pull/184): Extend `Performance/ReverseEach` to register an offense for `reverse.each_with_index`. ([@olliebennett][])
 
 ### Changes
 
@@ -183,3 +184,4 @@
 [@fatkodima]: https://github.com/fatkodima
 [@dvandersluis]: https://github.com/dvandersluis
 [@ghiculescu]: https://github.com/ghiculescu
+[@olliebennett]: https://github.com/olliebennett

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1387,8 +1387,9 @@ end
 | -
 |===
 
-This cop is used to identify usages of `reverse.each` and
-change them to use `reverse_each` instead.
+This cop is used to identify usages of `reverse.each` (or
+`reverse.each_with_index`) and change them to use
+`reverse_each` (or `reverse_each.with_index`) instead.
 
 === Examples
 
@@ -1396,9 +1397,11 @@ change them to use `reverse_each` instead.
 ----
 # bad
 [].reverse.each
+[].reverse.each_with_index
 
 # good
 [].reverse_each
+[].reverse_each.with_index
 ----
 
 === References

--- a/lib/rubocop/cop/performance/reverse_each.rb
+++ b/lib/rubocop/cop/performance/reverse_each.rb
@@ -3,44 +3,53 @@
 module RuboCop
   module Cop
     module Performance
-      # This cop is used to identify usages of `reverse.each` and
-      # change them to use `reverse_each` instead.
+      # This cop is used to identify usages of `reverse.each` (or
+      # `reverse.each_with_index`) and change them to use
+      # `reverse_each` (or `reverse_each.with_index`) instead.
       #
       # @example
       #   # bad
       #   [].reverse.each
+      #   [].reverse.each_with_index
       #
       #   # good
       #   [].reverse_each
+      #   [].reverse_each.with_index
       class ReverseEach < Base
         include RangeHelp
         extend AutoCorrector
 
-        MSG = 'Use `reverse_each` instead of `reverse.each`.'
-        RESTRICT_ON_SEND = %i[each].freeze
-        UNDERSCORE = '_'
+        MSG = 'Use `reverse%<prefer_method>s` instead of `reverse.%<current_method>s`.'
+        RESTRICT_ON_SEND = %i[each each_with_index].freeze
 
         def_node_matcher :reverse_each?, <<~MATCHER
-          (send $(send _ :reverse) :each)
+          (send $(send _ :reverse) ${:each :each_with_index})
         MATCHER
 
         def on_send(node)
-          reverse_each?(node) do |receiver|
-            location_of_reverse = receiver.loc.selector.begin_pos
-            end_location = node.loc.selector.end_pos
+          reverse_each?(node) do |receiver, current_method|
+            prefer_method = current_method == :each ? '_each' : '_each.with_index'
+            message = format(MSG, current_method: current_method, prefer_method: prefer_method)
 
-            range = range_between(location_of_reverse, end_location)
-
-            add_offense(range) do |corrector|
-              corrector.replace(replacement_range(node), UNDERSCORE)
-            end
+            register_offense(receiver, node, message, prefer_method)
           end
         end
 
         private
 
+        def register_offense(receiver, node, msg, replacement)
+          location_of_reverse = receiver.loc.selector.begin_pos
+          end_location = node.loc.selector.end_pos
+
+          range = range_between(location_of_reverse, end_location)
+
+          add_offense(range, message: msg) do |corrector|
+            corrector.replace(replacement_range(node), replacement)
+          end
+        end
+
         def replacement_range(node)
-          range_between(node.loc.dot.begin_pos, node.loc.selector.begin_pos)
+          range_between(node.loc.dot.begin_pos, node.loc.selector.end_pos)
         end
       end
     end

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -10,11 +10,26 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
     RUBY
   end
 
+  it 'registers an offense when each_with_index is called on reverse' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3].reverse.each_with_index { |e, idx| puts [idx, e] }
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use `reverse_each.with_index` instead of `reverse.each_with_index`.
+    RUBY
+  end
+
   it 'registers an offense when each is called on reverse on a variable' do
     expect_offense(<<~RUBY)
       arr = [1, 2, 3]
       arr.reverse.each { |e| puts e }
           ^^^^^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
+    RUBY
+  end
+
+  it 'registers an offense when each_with_index is called on reverse on a variable' do
+    expect_offense(<<~RUBY)
+      arr = [1, 2, 3]
+      arr.reverse.each_with_index { |e, idx| puts [idx, e] }
+          ^^^^^^^^^^^^^^^^^^^^^^^ Use `reverse_each.with_index` instead of `reverse.each_with_index`.
     RUBY
   end
 
@@ -26,6 +41,17 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
 
       arr.reverse.each { |e| puts e }
           ^^^^^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
+    RUBY
+  end
+
+  it 'registers an offense when each_with_index is called on reverse on a method call' do
+    expect_offense(<<~RUBY)
+      def arr
+        [1, 2, 3]
+      end
+
+      arr.reverse.each_with_index { |e, idx| puts [idx, e] }
+          ^^^^^^^^^^^^^^^^^^^^^^^ Use `reverse_each.with_index` instead of `reverse.each_with_index`.
     RUBY
   end
 
@@ -42,6 +68,19 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
     RUBY
   end
 
+  it 'registers an offense for a multi-line reverse.each_with_index' do
+    expect_offense(<<~RUBY)
+      def arr
+        [1, 2, 3]
+      end
+
+      arr.
+        reverse.
+        ^^^^^^^^ Use `reverse_each.with_index` instead of `reverse.each_with_index`.
+        each_with_index { |e, idx| puts [idx, e] }
+    RUBY
+  end
+
   it 'does not register an offense when reverse is used without each' do
     expect_no_offenses('[1, 2, 3].reverse')
   end
@@ -50,11 +89,21 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
     expect_no_offenses('[1, 2, 3].each { |e| puts e }')
   end
 
+  it 'does not register an offense when each_with_index is used without reverse' do
+    expect_no_offenses('[1, 2, 3].each_with_index { |e, idx| puts [idx, e] }')
+  end
+
   context 'autocorrect' do
     it 'corrects reverse.each to reverse_each' do
       new_source = autocorrect_source('[1, 2].reverse.each { |e| puts e }')
 
       expect(new_source).to eq('[1, 2].reverse_each { |e| puts e }')
+    end
+
+    it 'corrects reverse.each_with_index to reverse_each.with_index' do
+      new_source = autocorrect_source('[1, 2].reverse.each_with_index { |e, idx| puts [idx, e] }')
+
+      expect(new_source).to eq('[1, 2].reverse_each.with_index { |e, idx| puts [idx, e] }')
     end
 
     it 'corrects reverse.each to reverse_each on a variable' do
@@ -66,6 +115,18 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
       expect(new_source).to eq(<<~RUBY)
         arr = [1, 2]
         arr.reverse_each { |e| puts e }
+      RUBY
+    end
+
+    it 'corrects reverse.each_with_index to reverse_each.with_index on a variable' do
+      new_source = autocorrect_source(<<~RUBY)
+        arr = [1, 2]
+        arr.reverse.each_with_index { |e, idx| puts [idx, e] }
+      RUBY
+
+      expect(new_source).to eq(<<~RUBY)
+        arr = [1, 2]
+        arr.reverse_each.with_index { |e, idx| puts [idx, e] }
       RUBY
     end
 
@@ -87,7 +148,25 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
       RUBY
     end
 
-    it 'corrects a multi-line reverse_each' do
+    it 'corrects reverse.each_with_index to reverse_each.with_index on a method call' do
+      new_source = autocorrect_source(<<~RUBY)
+        def arr
+          [1, 2]
+        end
+
+        arr.reverse.each_with_index { |e, idx| puts [idx, e] }
+      RUBY
+
+      expect(new_source).to eq(<<~RUBY)
+        def arr
+          [1, 2]
+        end
+
+        arr.reverse_each.with_index { |e, idx| puts [idx, e] }
+      RUBY
+    end
+
+    it 'corrects a multi-line reverse.each' do
       new_source = autocorrect_source(<<~RUBY)
         def arr
           [1, 2]
@@ -105,6 +184,27 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
 
         arr.
           reverse_each { |e| puts e }
+      RUBY
+    end
+
+    it 'corrects a multi-line reverse.each_with_index' do
+      new_source = autocorrect_source(<<~RUBY)
+        def arr
+          [1, 2]
+        end
+
+        arr.
+          reverse.
+          each_with_index { |e, idx| puts [idx, e] }
+      RUBY
+
+      expect(new_source).to eq(<<~RUBY)
+        def arr
+          [1, 2]
+        end
+
+        arr.
+          reverse_each.with_index { |e, idx| puts [idx, e] }
       RUBY
     end
   end


### PR DESCRIPTION
The `Performance/ReverseEach` cop already registers and corrects `reverse.each` to `reverse_each`. However, it ignores cases of `reverse.each_with_index` which this PR corrects to `reverse_each.with_index`.

I feel this belongs in the existing cop rather than warranting a new one, and couldn't think of any reason someone might want to configure anything here; open to ideas.

Code-wise, I've introduced some duplication in the specs which could be addressed, and the cop itself is regrettably a little more hard-coded now; I'm open to refactoring suggestions (or anyone taking over)!

## Benchmark

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  gem 'benchmark-ips'
end

ARRAY = 1.upto(1000).to_a.shuffle

Benchmark.ips do |x|
  x.report('Array#reverse + each_with_index') do
    ARRAY.reverse.each_with_index
  end

  x.report('Array#reverse_each + with_index') do 
    ARRAY.reverse_each.with_index
  end

  x.compare!
end

```

```
Warming up --------------------------------------
Array#reverse + each_with_index
                        35.883k i/100ms
Array#reverse_each + with_index
                       140.577k i/100ms
Calculating -------------------------------------
Array#reverse + each_with_index
                        381.871k (±24.8%) i/s -      1.830M in   5.059969s
Array#reverse_each + with_index
                          1.467M (± 6.1%) i/s -      7.310M in   5.002356s

Comparison:
Array#reverse_each + with_index:  1466559.5 i/s
Array#reverse + each_with_index:   381871.1 i/s - 3.84x  (± 0.00) slower
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
