### PR TITLE
Update dependencies and improve version locks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ workflows:
   build:
     jobs:
       - documentation-checks
+      # Check minimal required Ruby version in `gemspec` file before changes
       - rake_default:
           name: Ruby 2.4
           image: circleci/ruby:2.4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,10 +92,6 @@ Performance/CollectionLiteralInLoop:
   Exclude:
     - 'spec/**/*.rb'
 
-# This disabling is a workaround for https://github.com/rubocop-hq/rubocop-rails/issues/374.
-RSpec/FactoryBot/CreateList:
-  Enabled: false
-
 RSpec/PredicateMatcher:
   EnforcedStyle: explicit
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,4 @@ gemspec
 gem 'bump', require: false
 gem 'rake'
 gem 'rspec'
-gem 'rubocop', github: 'rubocop-hq/rubocop'
-gem 'rubocop-rspec', '~> 1.29.0'
 gem 'yard', '~> 0.9'

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -7,7 +7,14 @@ Gem::Specification.new do |s|
   s.name = 'rubocop-performance'
   s.version = RuboCop::Performance::Version::STRING
   s.platform = Gem::Platform::RUBY
+
+  # Using EOL Ruby versions is (gem, application) users choice
+  # (of course, not recommended).
+  # We will support them for one year after EOL for migration.
+  # Ruby 2.4 support will end at March 31, 2021:
+  # https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/
   s.required_ruby_version = '>= 2.4.0'
+
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<~DESCRIPTION
     A collection of RuboCop cops to check for performance optimizations
@@ -31,7 +38,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-performance/issues'
   }
 
-  s.add_runtime_dependency('rubocop', '>= 0.90.0')
-  s.add_runtime_dependency('rubocop-ast', '>= 0.4.0')
-  s.add_development_dependency('simplecov')
+  s.add_runtime_dependency('rubocop', '~> 0.93.1')
+  s.add_development_dependency('rubocop-rspec', '~> 1.44')
+  s.add_development_dependency('simplecov', '~> 0.18.0')
 end

--- a/spec/rubocop/cop/performance/bind_call_spec.rb
+++ b/spec/rubocop/cop/performance/bind_call_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::Performance::BindCall, :config do
   # https://github.com/rubocop-hq/rubocop/pull/7605
   let(:ruby_version) { 2.7 }
 
-  context 'TargetRubyVersion <= 2.6', :ruby26 do
+  context 'when TargetRubyVersion <= 2.6', :ruby26 do
     it 'does not register an offense when using `bind(obj).call(args, ...)`' do
       expect_no_offenses(<<~RUBY)
         umethod.bind(obj).call(foo, bar)
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Performance::BindCall, :config do
     end
   end
 
-  context 'TargetRubyVersion >= 2.7', :ruby27 do
+  context 'when TargetRubyVersion >= 2.7', :ruby27 do
     it 'registers an offense when using `bind(obj).call(args, ...)`' do
       expect_offense(<<~RUBY)
         umethod.bind(obj).call(foo, bar)

--- a/spec/rubocop/cop/performance/delete_prefix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_prefix_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
   let(:cop_config) { { 'SafeMultiline' => safe_multiline } }
   let(:safe_multiline) { true }
 
-  context 'TargetRubyVersion <= 2.4', :ruby24 do
+  context 'when TargetRubyVersion <= 2.4', :ruby24 do
     it "does not register an offense when using `gsub(/\Aprefix/, '')`" do
       expect_no_offenses(<<~RUBY)
         str.gsub(/\\Aprefix/, '')
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
     end
   end
 
-  context 'TargetRubyVersion >= 2.5', :ruby25 do
+  context 'when TargetRubyVersion >= 2.5', :ruby25 do
     context 'when using `\A` as starting pattern' do
       it "registers an offense and corrects when `gsub(/\Aprefix/, '')`" do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/performance/delete_suffix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_suffix_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
   let(:cop_config) { { 'SafeMultiline' => safe_multiline } }
   let(:safe_multiline) { true }
 
-  context 'TargetRubyVersion <= 2.4', :ruby24 do
+  context 'when TargetRubyVersion <= 2.4', :ruby24 do
     it "does not register an offense when using `gsub(/suffix\z/, '')`" do
       expect_no_offenses(<<~RUBY)
         str.gsub(/suffix\\z/, '')
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
     end
   end
 
-  context 'TargetRubyVersion >= 2.5', :ruby25 do
+  context 'when TargetRubyVersion >= 2.5', :ruby25 do
     context 'when using `\z` as ending pattern' do
       it "registers an offense and corrects when `gsub(/suffix\z/, '')`" do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::Performance::Detect do
       RUBY
     end
 
-    it "registers an offense with #{method} short syntax and [0]" do
+    it "registers an offense with #{method} short syntax and [-1]" do
       expect_offense(<<~RUBY, method: method)
         [1, 2, 3].#{method}(&:even?)[-1]
                   ^{method}^^^^^^^^^^^^^ Use `reverse.detect` instead of `#{method}[-1]`.


### PR DESCRIPTION
* Use stable `rubocop` version and improve its version lock.
* Drop explicit `rubocop-ast` dependency.
* Improve `simplecov` version lock.
  Not-stable versions (less than major 1) should be locked at patch-version,
  because every minor version can be not backward-compatible.
* Take `rubocop-rspec` from `Gemfile` to `.gemspec` and update it.
* Resolve new `rubocop-rspec` offenses.
* Add documentation about EOL Ruby versions support.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
