### PR TITLE
Suppress `Lint/ToEnumArguments`'s offense

### DIFF
--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -80,11 +80,11 @@ module RuboCop
         def calls_to_report(argname, body)
           return [] if blockarg_assigned?(body, argname)
 
-          calls = to_enum(:blockarg_calls, body, argname)
+          blockarg_calls(body, argname).map do |call|
+            return [] if args_include_block_pass?(call)
 
-          return [] if calls.any? { |call| args_include_block_pass?(call) }
-
-          calls
+            call
+          end
         end
 
         def args_include_block_pass?(blockcall)


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8955#issuecomment-717604989

This PR suppresses the following `Lint/ToEnumArguments` offense.

```console
% cd path/to/rubocop-performance
% bundle exec rake
(snip)

Offenses:

lib/rubocop/cop/performance/redundant_block_call.rb:83:19: W:
Lint/ToEnumArguments: Ensure you correctly provided all the arguments.
          calls = to_enum(:blockarg_calls, body, argname)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

96 files inspected, 1 offense detected
RuboCop failed!
```

Thank you for the improving suggestion @marcandre!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
