### PR TITLE
[Fix #171] Extend auto-correction support for `Performance/Sum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#151](https://github.com/rubocop-hq/rubocop-performance/issues/151): Add new `Performance/ConstantRegexp` cop. ([@fatkodima][])
 * [#175](https://github.com/rubocop-hq/rubocop-performance/pull/175): Add new `Performance/ArraySemiInfiniteRangeSlice` cop. ([@fatkodima][])
 * [#189](https://github.com/rubocop-hq/rubocop-performance/pull/189): Support auto-correction for `Performance/Caller`. ([@koic][])
+* [#171](https://github.com/rubocop-hq/rubocop-performance/issues/171): Extend auto-correction support for `Performance/Sum`. ([@koic][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1788,15 +1788,39 @@ This cop identifies places where `gsub` can be replaced by
 This cop identifies places where custom code finding the sum of elements
 in some Enumerable object can be replaced by `Enumerable#sum` method.
 
+This cop can change auto-correction scope depending on the value of
+`SafeAutoCorrect`.
+Its auto-correction is marked as safe by default (`SafeAutoCorrect: true`)
+to prevent `TypeError` in auto-correced code when initial value is not
+specified as shown below:
+
+[source,ruby]
+----
+['a', 'b'].sum # => (String can't be coerced into Integer)
+----
+
+Therefore if initial value is not specified, unsafe auto-corrected will not occur.
+
+If you always want to enable auto-correction, you can set `SafeAutoCorrect: false`.
+
+[source,yaml]
+----
+Performance/Sum:
+  SafeAutoCorrect: false
+----
+
+Please note that the auto-correction command line option will be changed from
+`rubocop -a` to `rubocop -A`, which includes unsafe auto-correction.
+
 === Examples
 
 [source,ruby]
 ----
 # bad
-[1, 2, 3].inject(:+)
+[1, 2, 3].inject(:+)                        # These bad cases with no initial value are unsafe and
+[1, 2, 3].inject(&:+)                       # will not be auto-correced by default. If you want to
+[1, 2, 3].reduce { |acc, elem| acc + elem } # auto-corrected, you can set `SafeAutoCorrect: false`.
 [1, 2, 3].reduce(10, :+)
-[1, 2, 3].inject(&:+)
-[1, 2, 3].reduce { |acc, elem| acc + elem }
 [1, 2, 3].map { |elem| elem ** 2 }.sum
 [1, 2, 3].collect(&:count).sum(10)
 

--- a/lib/rubocop/cop/performance/sum.rb
+++ b/lib/rubocop/cop/performance/sum.rb
@@ -6,12 +6,36 @@ module RuboCop
       # This cop identifies places where custom code finding the sum of elements
       # in some Enumerable object can be replaced by `Enumerable#sum` method.
       #
+      # This cop can change auto-correction scope depending on the value of
+      # `SafeAutoCorrect`.
+      # Its auto-correction is marked as safe by default (`SafeAutoCorrect: true`)
+      # to prevent `TypeError` in auto-correced code when initial value is not
+      # specified as shown below:
+      #
+      # [source,ruby]
+      # ----
+      # ['a', 'b'].sum # => (String can't be coerced into Integer)
+      # ----
+      #
+      # Therefore if initial value is not specified, unsafe auto-corrected will not occur.
+      #
+      # If you always want to enable auto-correction, you can set `SafeAutoCorrect: false`.
+      #
+      # [source,yaml]
+      # ----
+      # Performance/Sum:
+      #   SafeAutoCorrect: false
+      # ----
+      #
+      # Please note that the auto-correction command line option will be changed from
+      # `rubocop -a` to `rubocop -A`, which includes unsafe auto-correction.
+      #
       # @example
       #   # bad
-      #   [1, 2, 3].inject(:+)
+      #   [1, 2, 3].inject(:+)                        # These bad cases with no initial value are unsafe and
+      #   [1, 2, 3].inject(&:+)                       # will not be auto-correced by default. If you want to
+      #   [1, 2, 3].reduce { |acc, elem| acc + elem } # auto-corrected, you can set `SafeAutoCorrect: false`.
       #   [1, 2, 3].reduce(10, :+)
-      #   [1, 2, 3].inject(&:+)
-      #   [1, 2, 3].reduce { |acc, elem| acc + elem }
       #   [1, 2, 3].map { |elem| elem ** 2 }.sum
       #   [1, 2, 3].collect(&:count).sum(10)
       #
@@ -111,7 +135,7 @@ module RuboCop
         end
 
         def autocorrect(corrector, init, range)
-          return if init.empty?
+          return if init.empty? && safe_autocorrect?
 
           replacement = build_good_method(init)
 


### PR DESCRIPTION
Fixes #171.

This PR makes `Performance/Sum` cop can be changed auto-correction scope depending on the value of `SafeAutoCorrect` in .rubocop.yml.

Its auto-correction is marked as safe by default (`SafeAutoCorrect: true`) to prevent `TypeError` in auto-correced code when initial value is not specified as shown below:

```ruby
['a', 'b'].sum # => (String can't be coerced into Integer)
```

Therefore if initial value is not specify as in that code, it will not be auto-corrected.

If user always want to enable auto-correction, user can set `SafeAutoCorrect: false`.

```yaml
Performance/Sum:
  SafeAutoCorrect: false
```

`SafeAutoCorrect` remains `true` by default, so the behavior does not change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
