### PR TITLE
Support auto-correction for `Performance/Caller`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#136](https://github.com/rubocop-hq/rubocop-performance/issues/136): Add new `Performance/MethodObjectAsBlock` cop. ([@fatkodima][])
 * [#151](https://github.com/rubocop-hq/rubocop-performance/issues/151): Add new `Performance/ConstantRegexp` cop. ([@fatkodima][])
 * [#175](https://github.com/rubocop-hq/rubocop-performance/pull/175): Add new `Performance/ArraySemiInfiniteRangeSlice` cop. ([@fatkodima][])
+* [#189](https://github.com/rubocop-hq/rubocop-performance/pull/189): Support auto-correction for `Performance/Caller`. ([@koic][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -32,6 +32,7 @@ Performance/Caller:
              Use `caller(n..n)` instead of `caller`.
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '1.9'
 
 Performance/CaseWhenSplat:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -173,9 +173,9 @@ end
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.49
-| -
+| 1.9
 |===
 
 This cop identifies places where `caller[n]`

--- a/spec/rubocop/cop/performance/caller_spec.rb
+++ b/spec/rubocop/cop/performance/caller_spec.rb
@@ -15,67 +15,99 @@ RSpec.describe RuboCop::Cop::Performance::Caller do
     expect_no_offenses('caller_locations')
   end
 
-  it 'registers an offense when :first is called on caller' do
+  it 'registers an offense and corrects when :first is called on caller' do
     expect(caller.first).to eq(caller(1..1).first)
     expect_offense(<<~RUBY)
       caller.first
       ^^^^^^^^^^^^ Use `caller(1..1).first` instead of `caller.first`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      caller(1..1).first
+    RUBY
   end
 
-  it 'registers an offense when :first is called on caller with 1' do
+  it 'registers an offense and corrects when :first is called on caller with 1' do
     expect(caller(1).first).to eq(caller(1..1).first)
     expect_offense(<<~RUBY)
       caller(1).first
-      ^^^^^^^^^^^^^^^ Use `caller(1..1).first` instead of `caller.first`.
+      ^^^^^^^^^^^^^^^ Use `caller(1..1).first` instead of `caller(1).first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      caller(1..1).first
     RUBY
   end
 
-  it 'registers an offense when :first is called on caller with 2' do
+  it 'registers an offense and corrects when :first is called on caller with 2' do
     expect(caller(2).first).to eq(caller(2..2).first)
     expect_offense(<<~RUBY)
       caller(2).first
-      ^^^^^^^^^^^^^^^ Use `caller(2..2).first` instead of `caller.first`.
+      ^^^^^^^^^^^^^^^ Use `caller(2..2).first` instead of `caller(2).first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      caller(2..2).first
     RUBY
   end
 
-  it 'registers an offense when :[] is called on caller' do
+  it 'registers an offense and corrects when :[] is called on caller' do
     expect(caller[1]).to eq(caller(2..2).first)
     expect_offense(<<~RUBY)
       caller[1]
       ^^^^^^^^^ Use `caller(2..2).first` instead of `caller[1]`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      caller(2..2).first
+    RUBY
   end
 
-  it 'registers an offense when :[] is called on caller with 1' do
+  it 'registers an offense and corrects when :[] is called on caller with 1' do
     expect(caller(1)[1]).to eq(caller(2..2).first)
     expect_offense(<<~RUBY)
       caller(1)[1]
-      ^^^^^^^^^^^^ Use `caller(2..2).first` instead of `caller[1]`.
+      ^^^^^^^^^^^^ Use `caller(2..2).first` instead of `caller(1)[1]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      caller(2..2).first
     RUBY
   end
 
-  it 'registers an offense when :[] is called on caller with 2' do
+  it 'registers an offense and corrects when :[] is called on caller with 2' do
     expect(caller(2)[1]).to eq(caller(3..3).first)
     expect_offense(<<~RUBY)
       caller(2)[1]
-      ^^^^^^^^^^^^ Use `caller(3..3).first` instead of `caller[1]`.
+      ^^^^^^^^^^^^ Use `caller(3..3).first` instead of `caller(2)[1]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      caller(3..3).first
     RUBY
   end
 
-  it 'registers an offense when :first is called on caller_locations also' do
+  it 'registers an offense and corrects when :first is called on caller_locations also' do
     expect(caller_locations.first.to_s).to eq(caller_locations(1..1).first.to_s)
     expect_offense(<<~RUBY)
       caller_locations.first
       ^^^^^^^^^^^^^^^^^^^^^^ Use `caller_locations(1..1).first` instead of `caller_locations.first`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      caller_locations(1..1).first
+    RUBY
   end
 
-  it 'registers an offense when :[] is called on caller_locations also' do
+  it 'registers an offense and corrects when :[] is called on caller_locations also' do
     expect(caller_locations[1].to_s).to eq(caller_locations(2..2).first.to_s)
     expect_offense(<<~RUBY)
       caller_locations[1]
       ^^^^^^^^^^^^^^^^^^^ Use `caller_locations(2..2).first` instead of `caller_locations[1]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      caller_locations(2..2).first
     RUBY
   end
 end


### PR DESCRIPTION
This PR supports auto-correction for `Performance/Caller`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
