### PR TITLE
Support autocorrect for `Performance/UnfreezeString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#175](https://github.com/rubocop-hq/rubocop-performance/pull/175): Add new `Performance/ArraySemiInfiniteRangeSlice` cop. ([@fatkodima][])
 * [#189](https://github.com/rubocop-hq/rubocop-performance/pull/189): Support auto-correction for `Performance/Caller`. ([@koic][])
 * [#171](https://github.com/rubocop-hq/rubocop-performance/issues/171): Extend auto-correction support for `Performance/Sum`. ([@koic][])
+* [#194](https://github.com/rubocop-hq/rubocop-performance/pull/194): Support auto-correction for `Performance/UnfreezeString`. ([@koic][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -305,7 +305,9 @@ Performance/TimesMap:
 Performance/UnfreezeString:
   Description: 'Use unary plus to get an unfrozen string literal.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.50'
+  VersionChanged: '1.9'
 
 Performance/UriDefaultParser:
   Description: 'Use `URI::DEFAULT_PARSER` instead of `URI::Parser.new`.'

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1883,9 +1883,9 @@ end
 
 | Enabled
 | Yes
-| No
+| Yes (Unsafe)
 | 0.50
-| -
+| 1.9
 |===
 
 In Ruby 2.3 or later, use unary plus operator to unfreeze a string
@@ -1895,6 +1895,7 @@ Unary plus operator is faster than `String#dup`.
 NOTE: `String.new` (without operator) is not exactly the same as `+''`.
 These differ in encoding. `String.new.encoding` is always `ASCII-8BIT`.
 However, `(+'').encoding` is the same as script encoding(e.g. `UTF-8`).
+Therefore, auto-correction is unsafe.
 So, if you expect `ASCII-8BIT` encoding, disable this cop.
 
 === Examples

--- a/spec/rubocop/cop/performance/unfreeze_string_spec.rb
+++ b/spec/rubocop/cop/performance/unfreeze_string_spec.rb
@@ -3,21 +3,29 @@
 RSpec.describe RuboCop::Cop::Performance::UnfreezeString, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense for an empty string with `.dup`' do
+  it 'registers an offense and corrects for an empty string with `.dup`' do
     expect_offense(<<~RUBY)
       "".dup
       ^^^^^^ Use unary plus to get an unfrozen string literal.
     RUBY
+
+    expect_correction(<<~RUBY)
+      +""
+    RUBY
   end
 
-  it 'registers an offense for a string with `.dup`' do
+  it 'registers an offense and corrects for a string with `.dup`' do
     expect_offense(<<~RUBY)
       "foo".dup
       ^^^^^^^^^ Use unary plus to get an unfrozen string literal.
     RUBY
+
+    expect_correction(<<~RUBY)
+      +"foo"
+    RUBY
   end
 
-  it 'registers an offense for a heredoc with `.dup`' do
+  it 'registers an offense and corrects for a heredoc with `.dup`' do
     expect_offense(<<~RUBY)
       <<TEXT.dup
       ^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
@@ -25,34 +33,57 @@ RSpec.describe RuboCop::Cop::Performance::UnfreezeString, :config do
         bar
       TEXT
     RUBY
+
+    expect_correction(<<~RUBY)
+      +<<TEXT
+        foo
+        bar
+      TEXT
+    RUBY
   end
 
-  it 'registers an offense for a string that contains a string' \
+  it 'registers an offense and corrects for a string that contains a string' \
      'interpolation with `.dup`' do
     expect_offense(<<~'RUBY')
       "foo#{bar}baz".dup
       ^^^^^^^^^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
     RUBY
+
+    expect_correction(<<~'RUBY')
+      +"foo#{bar}baz"
+    RUBY
   end
 
-  it 'registers an offense for `String.new`' do
+  it 'registers an offense and corrects for `String.new`' do
     expect_offense(<<~RUBY)
       String.new
       ^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
     RUBY
+
+    expect_correction(<<~RUBY)
+      +''
+    RUBY
   end
 
-  it 'registers an offense for `String.new` with an empty string' do
+  it 'registers an offense and corrects for `String.new` with an empty string' do
     expect_offense(<<~RUBY)
       String.new('')
       ^^^^^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
     RUBY
+
+    expect_correction(<<~RUBY)
+      +''
+    RUBY
   end
 
-  it 'registers an offense for `String.new` with a string' do
+  it 'registers an offense and corrects for `String.new` with a string' do
     expect_offense(<<~RUBY)
       String.new('foo')
       ^^^^^^^^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      +'foo'
     RUBY
   end
 


### PR DESCRIPTION
This PR supports autocorrect for `Performance/UnfreezeString`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
