### PR TITLE
Fix incorrect replacement recommendation for `Performance/ChainArrayAllocation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#185](https://github.com/rubocop-hq/rubocop-performance/issues/185): Fix incorrect replacement recommendation for `Performance/ChainArrayAllocation`. ([@fatkodima][])
+
 ## 1.9.0 (2020-11-17)
 
 ### New features

--- a/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
+++ b/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
@@ -1,26 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
-  subject(:cop) { described_class.new(config) }
-
-  def generate_message(method_one, method_two)
-    "Use unchained `#{method_one}!` and `#{method_two}!` "\
-    '(followed by `return array` if required) instead of '\
-    "chaining `#{method_one}...#{method_two}`."
-  end
-
-  shared_examples 'map_and_flat' do |method, method_two|
-    it "registers an offense when calling #{method}...#{method_two}" do
-      expect_offense(<<~RUBY, method: method, method_two: method_two)
-        [1, 2, 3, 4].#{method} { |e| [e, e] }.#{method_two}
-                     _{method}               ^^{method_two} #{generate_message(method, method_two)}
-      RUBY
-    end
-  end
-
-  describe 'configured to only warn when flattening one level' do
-    it_behaves_like('map_and_flat', 'map', 'flatten')
-  end
+RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation do
+  subject(:cop) { described_class.new }
 
   describe 'Methods that require an argument' do
     it 'does not register an offense for `first.uniq`' do
@@ -33,7 +14,7 @@ RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
     it 'registers an offense for `first(10).uniq`' do
       expect_offense(<<~RUBY)
         [1, 2, 3, 4].first(10).uniq
-                              ^^^^^ Use unchained `first!` and `uniq!` (followed by `return array` if required) instead of chaining `first...uniq`.
+                              ^^^^^ Use unchained `first` and `uniq!` (followed by `return array` if required) instead of chaining `first...uniq`.
       RUBY
     end
 
@@ -41,7 +22,7 @@ RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
       expect_offense(<<~RUBY)
         variable = 42
         [1, 2, 3, 4].first(variable).uniq
-                                    ^^^^^ Use unchained `first!` and `uniq!` (followed by `return array` if required) instead of chaining `first...uniq`.
+                                    ^^^^^ Use unchained `first` and `uniq!` (followed by `return array` if required) instead of chaining `first...uniq`.
       RUBY
     end
   end
@@ -55,7 +36,7 @@ RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
 
       expect_offense(<<~RUBY)
         [1, 2, 3, 4].zip {|f| }.zip.uniq
-                                   ^^^^^ Use unchained `zip!` and `uniq!` (followed by `return array` if required) instead of chaining `zip...uniq`.
+                                   ^^^^^ Use unchained `zip` and `uniq!` (followed by `return array` if required) instead of chaining `zip...uniq`.
       RUBY
     end
   end


### PR DESCRIPTION
Closes #185

The real change is this line - https://github.com/rubocop-hq/rubocop-performance/pull/196/files#diff-aadc09c37851b4bcdde6d9af4f194ba5bd2578117e64170d87d2174e17772a63R52

Other changes are a small refactoring rewriting a patterns with `%CONST` feature.

cc @marcandre 