### PR TITLE
[Fix #197] Disable `Performance/ArraySemiInfiniteRangeSlice` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#185](https://github.com/rubocop-hq/rubocop-performance/issues/185): Fix incorrect replacement recommendation for `Performance/ChainArrayAllocation`. ([@fatkodima][])
 
+### Changes
+
+* [#197](https://github.com/rubocop-hq/rubocop-performance/issues/197): Disable `Performance/ArraySemiInfiniteRangeSlice` cop. ([@tejasbubane][])
+
 ## 1.9.0 (2020-11-17)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -9,7 +9,11 @@ Performance/AncestorsInclude:
 
 Performance/ArraySemiInfiniteRangeSlice:
   Description: 'Identifies places where slicing arrays with semi-infinite ranges can be replaced by `Array#take` and `Array#drop`.'
-  Enabled: pending
+  # This cop was created due to a mistake in microbenchmark.
+  # Refer https://github.com/rubocop-hq/rubocop-performance/pull/175#issuecomment-731892717
+  Enabled: false
+  # Unsafe for string slices because strings do not have `#take` and `#drop` methods.
+  Safe: false
   VersionAdded: '1.9'
 
 Performance/BigDecimalWithNumericArgument:

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -37,15 +37,18 @@ NOTE: Required Ruby version: 2.7
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
-| Yes
-| Yes
+| Disabled
+| No
+| Yes (Unsafe)
 | 1.9
 | -
 |===
 
 This cop identifies places where slicing arrays with semi-infinite ranges
 can be replaced by `Array#take` and `Array#drop`.
+This cop was created due to a mistake in microbenchmark and hence is disabled by default.
+Refer https://github.com/rubocop-hq/rubocop-performance/pull/175#issuecomment-731892717
+This cop is also unsafe for string slices because strings do not have `#take` and `#drop` methods.
 
 === Examples
 

--- a/lib/rubocop/cop/performance/array_semi_infinite_range_slice.rb
+++ b/lib/rubocop/cop/performance/array_semi_infinite_range_slice.rb
@@ -5,6 +5,9 @@ module RuboCop
     module Performance
       # This cop identifies places where slicing arrays with semi-infinite ranges
       # can be replaced by `Array#take` and `Array#drop`.
+      # This cop was created due to a mistake in microbenchmark and hence is disabled by default.
+      # Refer https://github.com/rubocop-hq/rubocop-performance/pull/175#issuecomment-731892717
+      # This cop is also unsafe for string slices because strings do not have `#take` and `#drop` methods.
       #
       # @example
       #   # bad


### PR DESCRIPTION
This cop is unsafe for string slices because string does not have `#take` and `#drop` methods. Although we could change the cop to skip literal strings, it still remains unsafe for variables which we cannot determine statically if they are arrays or strings.

Closes #197, #198 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/