### PR TITLE
Fix an incorrect auto-correct for `Performance/ReverseEach`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#201](https://github.com/rubocop-hq/rubocop-performance/pull/201): Fix an incorrect auto-correct for `Performance/ReverseEach` when using multi-line `reverse.each` with leading dot. ([@koic][])
+
 ## 1.9.1 (2020-11-28)
 
 ### Bug fixes

--- a/lib/rubocop/cop/performance/reverse_each.rb
+++ b/lib/rubocop/cop/performance/reverse_each.rb
@@ -18,29 +18,25 @@ module RuboCop
 
         MSG = 'Use `reverse_each` instead of `reverse.each`.'
         RESTRICT_ON_SEND = %i[each].freeze
-        UNDERSCORE = '_'
 
         def_node_matcher :reverse_each?, <<~MATCHER
-          (send $(send _ :reverse) :each)
+          (send (send _ :reverse) :each)
         MATCHER
 
         def on_send(node)
-          reverse_each?(node) do |receiver|
-            location_of_reverse = receiver.loc.selector.begin_pos
-            end_location = node.loc.selector.end_pos
-
-            range = range_between(location_of_reverse, end_location)
+          reverse_each?(node) do
+            range = offense_range(node)
 
             add_offense(range) do |corrector|
-              corrector.replace(replacement_range(node), UNDERSCORE)
+              corrector.replace(range, 'reverse_each')
             end
           end
         end
 
         private
 
-        def replacement_range(node)
-          range_between(node.loc.dot.begin_pos, node.loc.selector.begin_pos)
+        def offense_range(node)
+          range_between(node.children.first.loc.selector.begin_pos, node.loc.selector.end_pos)
         end
       end
     end

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -87,24 +87,47 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
       RUBY
     end
 
-    it 'corrects a multi-line reverse_each' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers and corrects when using multi-line `reverse.each` with trailing dot' do
+      expect_offense(<<~RUBY)
         def arr
           [1, 2]
         end
 
         arr.
           reverse.
+          ^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
           each { |e| puts e }
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         def arr
           [1, 2]
         end
 
         arr.
           reverse_each { |e| puts e }
+      RUBY
+    end
+
+    it 'registers and corrects when using multi-line `reverse.each` with leading dot' do
+      expect_offense(<<~RUBY)
+        def arr
+          [1, 2]
+        end
+
+        arr
+          .reverse
+           ^^^^^^^ Use `reverse_each` instead of `reverse.each`.
+          .each { |e| puts e }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def arr
+          [1, 2]
+        end
+
+        arr
+          .reverse_each { |e| puts e }
       RUBY
     end
   end


### PR DESCRIPTION
Fixes https://github.com/testdouble/standard/issues/230.

This PR fixes the following incorrect auto-correct for `Performance/ReverseEach` when using multi-line `reverse.each` with leading dot.

```ruby
% cat example.rb
[1, 2, 3]
  .reverse
  .each do |idx|
    puts idx
  end
```

## Before

```console
% bundle exec rubocop -a --only Performance/ReverseEach
% cat example.rb
[1, 2, 3]
  .reverse
  _each do |idx|
    puts idx
  end
```

## After

```console
% bundle exec rubocop -a --only Performance/ReverseEach
% cat example.rb
[1, 2, 3]
  .reverse_each do |idx|
    puts idx
  end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
