### PR TITLE
[Fix #205] Update `Performance/ConstantRegexp` to allow memoized regexps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#205](https://github.com/rubocop-hq/rubocop-performance/issues/205): Update `Performance/ConstantRegexp` to allow memoized regexps. ([@dvandersluis][])
+
 ## 1.9.2 (2021-01-01)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -80,6 +80,7 @@ Performance/ConstantRegexp:
   Description: 'Finds regular expressions with dynamic components that are all constants.'
   Enabled: pending
   VersionAdded: '1.9'
+  VersionChanged: <<next>>
 
 Performance/Count:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -453,15 +453,15 @@ array.sort_by { |a| a[:foo] }
 | Yes
 | Yes
 | 1.9
-| -
+| <<next>>
 |===
 
 This cop finds regular expressions with dynamic components that are all constants.
 
 Ruby allocates a new Regexp object every time it executes a code containing such
-a regular expression. It is more efficient to extract it into a constant
-or add an `/o` option to perform `#{}` interpolation only once and reuse that
-Regexp object.
+a regular expression. It is more efficient to extract it into a constant,
+memoize it, or add an `/o` option to perform `#{}` interpolation only once and
+reuse that Regexp object.
 
 === Examples
 
@@ -481,6 +481,11 @@ end
 # good
 def tokens(pattern)
   pattern.scan(TOKEN).reject { |token| token.match?(/\A#{SEPARATORS}\Z/o) }
+end
+
+# good
+def separators
+  @separators ||= /\A#{SEPARATORS}\Z/
 end
 ----
 

--- a/lib/rubocop/cop/performance/constant_regexp.rb
+++ b/lib/rubocop/cop/performance/constant_regexp.rb
@@ -6,9 +6,9 @@ module RuboCop
       # This cop finds regular expressions with dynamic components that are all constants.
       #
       # Ruby allocates a new Regexp object every time it executes a code containing such
-      # a regular expression. It is more efficient to extract it into a constant
-      # or add an `/o` option to perform `#{}` interpolation only once and reuse that
-      # Regexp object.
+      # a regular expression. It is more efficient to extract it into a constant,
+      # memoize it, or add an `/o` option to perform `#{}` interpolation only once and
+      # reuse that Regexp object.
       #
       # @example
       #
@@ -28,13 +28,18 @@ module RuboCop
       #     pattern.scan(TOKEN).reject { |token| token.match?(/\A#{SEPARATORS}\Z/o) }
       #   end
       #
+      #   # good
+      #   def separators
+      #     @separators ||= /\A#{SEPARATORS}\Z/
+      #   end
+      #
       class ConstantRegexp < Base
         extend AutoCorrector
 
-        MSG = 'Extract this regexp into a constant or append an `/o` option to its options.'
+        MSG = 'Extract this regexp into a constant, memoize it, or append an `/o` option to its options.'
 
         def on_regexp(node)
-          return if within_const_assignment?(node) ||
+          return if within_allowed_assignment?(node) ||
                     !include_interpolated_const?(node) ||
                     node.single_interpolation?
 
@@ -45,8 +50,8 @@ module RuboCop
 
         private
 
-        def within_const_assignment?(node)
-          node.each_ancestor(:casgn).any?
+        def within_allowed_assignment?(node)
+          node.each_ancestor(:casgn, :or_asgn).any?
         end
 
         def_node_matcher :regexp_escape?, <<~PATTERN

--- a/spec/rubocop/cop/performance/constant_regexp_spec.rb
+++ b/spec/rubocop/cop/performance/constant_regexp_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Performance::ConstantRegexp do
   it 'registers an offense and corrects when regexp contains interpolated constant' do
     expect_offense(<<~RUBY)
       str.match?(/\A\#{CONST}/)
-                 ^^^^^^^^^^^ Extract this regexp into a constant or append an `/o` option to its options.
+                 ^^^^^^^^^^^ Extract this regexp into a constant, memoize it, or append an `/o` option to its options.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Performance::ConstantRegexp do
   it 'registers an offense and corrects when regexp contains multiple interpolated constants' do
     expect_offense(<<~RUBY)
       str.match?(/\A\#{CONST1}something\#{CONST2}\z/)
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Extract this regexp into a constant or append an `/o` option to its options.
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Extract this regexp into a constant, memoize it, or append an `/o` option to its options.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Performance::ConstantRegexp do
   it 'registers an offense and corrects when regexp contains `Regexp.escape` on constant' do
     expect_offense(<<~RUBY)
       str.match?(/\A\#{CONST1}something\#{Regexp.escape(CONST2)}\z/)
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Extract this regexp into a constant or append an `/o` option to its options.
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Extract this regexp into a constant, memoize it, or append an `/o` option to its options.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -45,6 +45,12 @@ RSpec.describe RuboCop::Cop::Performance::ConstantRegexp do
   it 'does not register an offense when regexp is within assignment to a constant' do
     expect_no_offenses(<<~RUBY)
       CONST = str.match?(/\#{ANOTHER_CONST}/)
+    RUBY
+  end
+
+  it 'does not register an offense when the regexp is memoized' do
+    expect_no_offenses(<<~RUBY)
+      @regexp ||= /\#{ANOTHER_CONST}/
     RUBY
   end
 


### PR DESCRIPTION
Fixes #205.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
