### PR TITLE
[Fix #207] Fix an error for `Performance/Sum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#190](https://github.com/rubocop-hq/rubocop-performance/pull/190): Add new `Performance/RedundantSplitRegexpArgument` cop. ([@mfbmina][])
 
+### Bug fixes
+
+* [#207](https://github.com/rubocop-hq/rubocop-performance/issues/207): Fix an error for `Performance/Sum` when using `map(&do_something).sum` without receiver. ([@koic][])
+
 ### Changes
 
 * [#205](https://github.com/rubocop-hq/rubocop-performance/issues/205): Update `Performance/ConstantRegexp` to allow memoized regexps. ([@dvandersluis][])

--- a/lib/rubocop/cop/performance/sum.rb
+++ b/lib/rubocop/cop/performance/sum.rb
@@ -150,7 +150,9 @@ module RuboCop
           replacement = build_good_method(init, block_pass)
 
           corrector.remove(sum_range)
-          corrector.replace(map_range, ".#{replacement}")
+
+          dot = '.' if map.receiver
+          corrector.replace(map_range, "#{dot}#{replacement}")
         end
 
         def sum_method_range(node)
@@ -228,7 +230,11 @@ module RuboCop
         end
 
         def method_call_with_args_range(node)
-          node.receiver.source_range.end.join(node.source_range.end)
+          if (receiver = node.receiver)
+            receiver.source_range.end.join(node.source_range.end)
+          else
+            node.source_range
+          end
         end
       end
     end

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -190,6 +190,17 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
       RUBY
     end
 
+    it "registers an offense and corrects when using `#{method}(&:count).sum`" do
+      expect_offense(<<~RUBY, method: method)
+        %{method}(&:count).sum
+        ^{method}^^^^^^^^^^^^^ Use `sum { ... }` instead of `%{method} { ... }.sum`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        sum(&:count)
+      RUBY
+    end
+
     it "registers an offense and corrects when using `array.#{method}(&:count).sum(10)`" do
       expect_offense(<<~RUBY, method: method)
         array.%{method}(&:count).sum(10)


### PR DESCRIPTION
Fixes #207.

This PR fixes an error for `Performance/Sum` when using `map(&do_something).sum` without receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
