### PR TITLE
Fix an incorrect auto-correct for `Performance/RedundantSplitRegexpArgument`

### DIFF
--- a/spec/rubocop/cop/performance/redundant_split_regexp_argument_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_split_regexp_argument_spec.rb
@@ -37,6 +37,39 @@ RSpec.describe RuboCop::Cop::Performance::RedundantSplitRegexpArgument do
     RUBY
   end
 
+  it 'registers an offense when the method is split and corrects correctly consecutive special string chars' do
+    expect_offense(<<~RUBY)
+      "foo\\n\\nbar\\n\\nbaz\\n\\n".split(/\\n\\n/)
+                                    ^^^^^^ Use string as argument instead of regexp.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      "foo\\n\\nbar\\n\\nbaz\\n\\n".split("\\n\\n")
+    RUBY
+  end
+
+  it 'registers an offense when the method is split and corrects correctly consecutive backslash escape chars' do
+    expect_offense(<<~RUBY)
+      "foo\\\\\\.bar".split(/\\\\\\./)
+                         ^^^^^^ Use string as argument instead of regexp.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      "foo\\\\\\.bar".split("\\\\\.")
+    RUBY
+  end
+
+  it 'registers an offense when the method is split and corrects correctly complex special string chars' do
+    expect_offense(<<~RUBY)
+      "foo\\nbar\\nbaz\\n".split(/foo\\n\\.\\n/)
+                              ^^^^^^^^^^^ Use string as argument instead of regexp.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      "foo\\nbar\\nbaz\\n".split("foo\\n.\\n")
+    RUBY
+  end
+
   it 'registers an offense when the method is split' do
     expect_offense(<<~RUBY)
       'a,b,c'.split(/,/)


### PR DESCRIPTION
Follow #190.

This PR fixes the following incorrect auto-correct for `Performance/RedundantSplitRegexpArgument` when using consecutive special string chars.

```console
% cat example.rb
"foo\nbar\nbaz\n".split(/\n\n/)

% bundle exec rubocop example.rb --only Performance/RedundantSplitRegexpArgument -a
Inspecting 1 file
C

Offenses:

example.rb:1:25: C: [Corrected]
Performance/RedundantSplitRegexpArgument: Use string as argument instead of regexp.
"foo\nbar\nbaz\n".split(/\n\n/)
                        ^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

## Before

```console
% cat example.rb
"foo\nbar\nbaz\n".split("nn")
```

## After

```console
% cat example.rb
"foo\nbar\nbaz\n".split("\n\n")
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
