### PR TITLE
Fix a false negative for `Performance/BindCall`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#207](https://github.com/rubocop-hq/rubocop-performance/issues/207): Fix an error for `Performance/Sum` when using `map(&do_something).sum` without receiver. ([@koic][])
+* [#210](https://github.com/rubocop-hq/rubocop-performance/pull/210): Fix a false negative for `Performance/BindCall` when receiver is not a method call. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/performance/bind_call.rb
+++ b/lib/rubocop/cop/performance/bind_call.rb
@@ -33,7 +33,7 @@ module RuboCop
         def_node_matcher :bind_with_call_method?, <<~PATTERN
           (send
             $(send
-              (send nil? _) :bind
+              _ :bind
               $(...)) :call
             $...)
         PATTERN
@@ -64,7 +64,7 @@ module RuboCop
 
         def correction_range(receiver, node)
           location_of_bind = receiver.loc.selector.begin_pos
-          location_of_call = node.loc.end.end_pos
+          location_of_call = node.source_range.end.end_pos
 
           range_between(location_of_bind, location_of_call)
         end

--- a/spec/rubocop/cop/performance/bind_call_spec.rb
+++ b/spec/rubocop/cop/performance/bind_call_spec.rb
@@ -25,6 +25,28 @@ RSpec.describe RuboCop::Cop::Performance::BindCall, :config do
       RUBY
     end
 
+    it 'registers an offense when using `Foo.do_something.bind(obj).call`' do
+      expect_offense(<<~RUBY)
+        Foo.do_something.bind(obj).call
+                         ^^^^^^^^^^^^^^ Use `bind_call(obj)` instead of `bind(obj).call()`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Foo.do_something.bind_call(obj)
+      RUBY
+    end
+
+    it 'registers an offense when using `CONSTANT.bind(obj).call`' do
+      expect_offense(<<~RUBY)
+        CONSTANT.bind(obj).call
+                 ^^^^^^^^^^^^^^ Use `bind_call(obj)` instead of `bind(obj).call()`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONSTANT.bind_call(obj)
+      RUBY
+    end
+
     it 'registers an offense when using `bind(obj).()`' do
       expect_offense(<<~RUBY)
         umethod.bind(obj).()


### PR DESCRIPTION
This PR fix a false negative for `Performance/BindCall`
when receiver is not a method call.

I heard that it could not be detected by the following changes in rails/rails.
https://github.com/rails/rails/commit/6515d6985d2b537486bd9d1faa95212a508dc42c

Thanks @kamipo.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
