### PR TITLE
Enable auto-correct for `Performance/StartWith` and `Performance/EndWith` cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changes
 
 * [#205](https://github.com/rubocop-hq/rubocop-performance/issues/205): Update `Performance/ConstantRegexp` to allow memoized regexps. ([@dvandersluis][])
+* [#212](https://github.com/rubocop-hq/rubocop-performance/pull/212): Enable unsafe auto-correct for `Performance/StartWith` and `Performance/EndWith` cops by default. ([@koic][])
 
 ## 1.9.2 (2021-01-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -137,11 +137,10 @@ Performance/EndWith:
   # object. Switching these methods has to be done with knowledge of the types
   # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
-  AutoCorrect: false
   Enabled: true
   SafeMultiline: true
   VersionAdded: '0.36'
-  VersionChanged: '1.6'
+  VersionChanged: '1.10'
 
 Performance/FixedSize:
   Description: 'Do not compute the size of statically sized objects except in constants.'
@@ -276,11 +275,10 @@ Performance/StartWith:
   # object. Switching these methods has to be done with knowledge of the types
   # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
-  AutoCorrect: false
   Enabled: true
   SafeMultiline: true
   VersionAdded: '0.36'
-  VersionChanged: '1.6'
+  VersionChanged: '1.10'
 
 Performance/StringInclude:
   Description: 'Use `String#include?` instead of a regex match with literal-only pattern.'

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -780,7 +780,7 @@ str.end_with?(var1, var2)
 | Yes
 | Yes (Unsafe)
 | 0.36
-| 1.6
+| 1.10
 |===
 
 This cop identifies unnecessary use of a regex where `String#end_with?` would suffice.
@@ -835,10 +835,6 @@ for receiver is multiline string.
 
 |===
 | Name | Default value | Configurable values
-
-| AutoCorrect
-| `false`
-| Boolean
 
 | SafeMultiline
 | `true`
@@ -1659,7 +1655,7 @@ str.squeeze!('a')
 | Yes
 | Yes (Unsafe)
 | 0.36
-| 1.6
+| 1.10
 |===
 
 This cop identifies unnecessary use of a regex where `String#start_with?` would suffice.
@@ -1714,10 +1710,6 @@ for receiver is multiline string.
 
 |===
 | Name | Default value | Configurable values
-
-| AutoCorrect
-| `false`
-| Boolean
 
 | SafeMultiline
 | `true`


### PR DESCRIPTION
This PR enables auto-correct for `Performance/StartWith` and `Performance/EndWith` cops.
These cops are expected to be performed as unsafe auto-correction by default.

Thanks for the feedback @amatsuda!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
